### PR TITLE
Ignore `timeout` events

### DIFF
--- a/src/test_inputs/timeout.json
+++ b/src/test_inputs/timeout.json
@@ -1,0 +1,5 @@
+{ "type": "suite", "event": "started", "test_count": 1 }
+{ "type": "test", "event": "started", "name": "tests::long_execution_time" }
+{ "type": "test", "event": "timeout", "name": "tests::long_execution_time" }
+{ "type": "test", "name": "tests::long_execution_time", "event": "ok" }
+{ "type": "suite", "event": "ok", "passed": 1, "failed": 0, "allowed_fail": 0, "ignored": 0, "measured": 0, "filtered_out": 0 }


### PR DESCRIPTION
When a test runs for longer than 60 seconds, an informative timeout event is emitted.

```
Human readable:
test tests::long_execution_time ... tests::long_execution_time has been running for over 60 seconds
JSON:
{ "type": "test", "name": "tests::long_execution_time", "event": "ok" }
``` 

At this point the test is not stopped, but continues running and will return its result at a later point in time. This event is currently unrecognized and causes cargo2junit to panic.

The regular test harness (as far as I could find out with a quick Google search) doesn't currently have a feature to set a hard limit on test execution time. Should such a feature be added before the JSON format becomes stable, handling of timeout events might need to be adapted in the future. This is documented through comments in code.