### PR TITLE
split fully qualified name into name + module path (reported as classname)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,279 +4,257 @@
 name = "aho-corasick"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
 dependencies = [
- "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr",
 ]
 
 [[package]]
 name = "autocfg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "cargo2junit"
 version = "0.1.5"
 dependencies = [
- "junit-report 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "junit-report",
+ "regex",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "chrono"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
 dependencies = [
- "num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer",
+ "num-traits",
+ "time",
 ]
 
 [[package]]
 name = "derive-getters"
-version = "0.0.7"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf5e3757f36260ee98609aa4360701bad80d1319c6d90641797b0d8acf097631"
 dependencies = [
- "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.13.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "itoa"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 
 [[package]]
 name = "junit-report"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e00ad2de771fc4988af88b02cbd618c08c17920208c35c4bbfe67ccfab31eb"
 dependencies = [
- "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "derive-getters 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono",
+ "derive-getters",
+ "thiserror",
+ "xml-rs",
 ]
 
 [[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.66"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
 
 [[package]]
 name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "num-integer"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
 dependencies = [
- "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg",
+ "num-traits",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
- "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "0.3.8"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
 dependencies = [
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "proc-macro2"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "0.5.2"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
- "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
 ]
-
-[[package]]
-name = "quote"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.1.56"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex"
 version = "1.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
 dependencies = [
- "aho-corasick 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+ "thread_local",
 ]
 
 [[package]]
 name = "regex-syntax"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 
 [[package]]
 name = "ryu"
-version = "1.0.2"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "serde"
-version = "1.0.104"
+version = "1.0.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736aac72d1eafe8e5962d1d1c3d99b0df526015ba40915cb3c49d042e92ec243"
 dependencies = [
- "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.104"
+version = "1.0.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0343ce212ac0d3d6afd9391ac8e9c9efe06b533c8d33f660f6390cc4093f57"
 dependencies = [
- "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.46"
+version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec2c5d7e739bc07a3e73381a39d61fdb5f671c60c1df26a130690665803d8226"
 dependencies = [
- "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
 name = "syn"
-version = "0.13.11"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5304cfdf27365b7585c25d4af91b35016ed21ef88f17ced89c7093b43dba8b6"
 dependencies = [
- "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
-name = "syn"
-version = "1.0.14"
+name = "thiserror"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
 dependencies = [
- "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "thread_local"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "winapi",
 ]
-
-[[package]]
-name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "winapi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 dependencies = [
- "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
 ]
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "xml-rs"
-version = "0.8.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[metadata]
-"checksum aho-corasick 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)" = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
-"checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
-"checksum chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "31850b4a4d6bae316f7a09e691c944c28299298837edc0a03f755618c23cbc01"
-"checksum derive-getters 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "46e122eb9a0dddd006cc7b6c256de8806e935be67d6d28db825a4ec958420f3c"
-"checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
-"checksum junit-report 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4a88c18be7e347afb3ef1a11fc37fb7b5fb5359273548c33c6ce1ba41e8afd"
-"checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-"checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
-"checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
-"checksum num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
-"checksum num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
-"checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
-"checksum proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3acb317c6ff86a4e579dfa00fc5e6cca91ecbb4e7eb2df0468805b674eb88548"
-"checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
-"checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
-"checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
-"checksum regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
-"checksum regex-syntax 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)" = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
-"checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
-"checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
-"checksum serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
-"checksum serde_json 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)" = "21b01d7f0288608a01dca632cf1df859df6fd6ffa885300fc275ce2ba6221953"
-"checksum syn 0.13.11 (registry+https://github.com/rust-lang/crates.io-index)" = "14f9bf6292f3a61d2c716723fdb789a41bbe104168e6f496dc6497e531ea1b9b"
-"checksum syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5"
-"checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
-"checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
-"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-"checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
-"checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
-"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-"checksum xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "541b12c998c5b56aa2b4e6f18f03664eef9a4fd0a246a55594efae6cc2d964b5"
+checksum = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT"
 maintenance = { status = "experimental" }
 
 [dependencies]
-junit-report = "0.2.0"
+junit-report = "^0.4.0"
 serde_json = "1.0.38"
 serde = { version = "1.0", features = ["derive"] }
 

--- a/src/expected_outputs/azfunc.json.out
+++ b/src/expected_outputs/azfunc.json.out
@@ -1,580 +1,517 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-  <testsuite id="0" name="cargo test #0" package="testsuite/cargo test #0" tests="192" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:05.997283800+00:00" time="0">
-    <testcase name="bindings::blob::tests::it_converts_from_str" time="0" />
-    <testcase name="bindings::blob::tests::it_converts_from_json" time="0" />
-    <testcase name="bindings::blob::tests::it_converts_from_string" time="0" />
-    <testcase name="bindings::blob::tests::it_converts_from_u8_slice" time="0" />
-    <testcase name="bindings::blob::tests::it_converts_from_typed_data" time="0" />
-    <testcase name="bindings::blob::tests::it_converts_from_u8_vec" time="0" />
-    <testcase name="bindings::blob::tests::it_converts_to_body" time="0" />
-    <testcase name="bindings::blob::tests::it_converts_to_json" time="0" />
-    <testcase name="bindings::blob::tests::it_converts_to_bytes" time="0" />
-    <testcase name="bindings::blob::tests::it_converts_to_string" time="0" />
-    <testcase name="bindings::blob::tests::it_converts_to_typed_data" time="0" />
-    <testcase name="bindings::blob::tests::it_displays_as_a_string" time="0" />
-    <testcase name="bindings::blob::tests::it_has_json_content" time="0" />
-    <testcase name="bindings::blob::tests::it_has_bytes_content" time="0" />
-    <testcase name="bindings::blob::tests::it_has_string_content" time="0" />
-    <testcase name="bindings::cosmos_db_document::tests::it_constructs_from_an_object_value" time="0" />
-    <testcase name="bindings::blob_trigger::tests::it_constructs" time="0" />
-    <testcase name="bindings::cosmos_db_document::tests::it_converts_from_str" time="0" />
-    <testcase name="bindings::cosmos_db_document::tests::it_converts_from_string" time="0" />
-    <testcase name="bindings::cosmos_db_document::tests::it_converts_from_value" time="0" />
-    <testcase name="bindings::cosmos_db_document::tests::it_converts_from_typed_data" time="0" />
-    <testcase name="bindings::cosmos_db_document::tests::it_converts_to_body" time="0" />
-    <testcase name="bindings::cosmos_db_document::tests::it_converts_to_string" time="0" />
-    <testcase name="bindings::cosmos_db_document::tests::it_converts_to_value" time="0" />
-    <testcase name="bindings::cosmos_db_document::tests::it_displays_as_json" time="0" />
-    <testcase name="bindings::cosmos_db_document::tests::it_converts_to_typed_data" time="0" />
-    <testcase name="bindings::cosmos_db_trigger::tests::it_constructs" time="0" />
-    <testcase name="bindings::cosmos_db_document::tests::it_panics_if_constructed_without_an_object_or_array" time="0" />
-    <testcase name="bindings::event_hub_message::tests::it_converts_from_json" time="0" />
-    <testcase name="bindings::event_grid_event::tests::it_constructs" time="0" />
-    <testcase name="bindings::event_hub_message::tests::it_converts_from_str" time="0" />
-    <testcase name="bindings::event_hub_message::tests::it_converts_from_string" time="0" />
-    <testcase name="bindings::event_hub_message::tests::it_converts_from_u8_slice" time="0" />
-    <testcase name="bindings::event_hub_message::tests::it_converts_to_body" time="0" />
-    <testcase name="bindings::event_hub_message::tests::it_converts_from_u8_vec" time="0" />
-    <testcase name="bindings::event_hub_message::tests::it_converts_to_bytes" time="0" />
-    <testcase name="bindings::event_hub_message::tests::it_converts_to_json" time="0" />
-    <testcase name="bindings::event_hub_message::tests::it_converts_to_string" time="0" />
-    <testcase name="bindings::event_hub_message::tests::it_converts_to_typed_data" time="0" />
-    <testcase name="bindings::event_hub_message::tests::it_displays_as_a_string" time="0" />
-    <testcase name="bindings::event_hub_message::tests::it_has_bytes_content" time="0" />
-    <testcase name="bindings::event_hub_message::tests::it_has_json_content" time="0" />
-    <testcase name="bindings::event_hub_message::tests::it_has_string_content" time="0" />
-    <testcase name="bindings::generic_input::tests::it_converts_from_typed_data" time="0" />
-    <testcase name="bindings::event_hub_trigger::tests::it_constructs" time="0" />
-    <testcase name="bindings::generic_output::tests::it_converts_from_double" time="0" />
-    <testcase name="bindings::generic_output::tests::it_converts_from_bytes" time="0" />
-    <testcase name="bindings::generic_output::tests::it_converts_from_integer" time="0" />
-    <testcase name="bindings::generic_output::tests::it_converts_from_str" time="0" />
-    <testcase name="bindings::generic_output::tests::it_converts_from_value" time="0" />
-    <testcase name="bindings::generic_output::tests::it_converts_from_string" time="0" />
-    <testcase name="bindings::generic_output::tests::it_converts_to_typed_data" time="0" />
-    <testcase name="bindings::generic_trigger::tests::it_constructs" time="0" />
-    <testcase name="bindings::http_request::tests::it_has_a_header" time="0" />
-    <testcase name="bindings::http_request::tests::it_has_a_bytes_body" time="0" />
-    <testcase name="bindings::http_request::tests::it_has_a_json_body" time="0" />
-    <testcase name="bindings::http_request::tests::it_has_a_query_parameter" time="0" />
-    <testcase name="bindings::http_request::tests::it_has_a_stream_body" time="0" />
-    <testcase name="bindings::http_request::tests::it_has_a_route_parameter" time="0" />
-    <testcase name="bindings::http_request::tests::it_has_a_string_body" time="0" />
-    <testcase name="bindings::http_request::tests::it_has_an_empty_body" time="0" />
-    <testcase name="bindings::http_request::tests::it_has_the_url" time="0" />
-    <testcase name="bindings::http_request::tests::it_has_the_method" time="0" />
-    <testcase name="bindings::http_response::tests::it_builds_with_a_bytes_body" time="0" />
-    <testcase name="bindings::http_response::tests::it_builds_with_a_json_body" time="0" />
-    <testcase name="bindings::http_response::tests::it_builds_with_a_status" time="0" />
-    <testcase name="bindings::http_response::tests::it_builds_with_a_string_body" time="0" />
-    <testcase name="bindings::http_response::tests::it_builds_with_headers" time="0" />
-    <testcase name="bindings::http_response::tests::it_converts_to_typed_data" time="0" />
-    <testcase name="bindings::http_response::tests::it_is_empty_by_default" time="0" />
-    <testcase name="bindings::queue_message::tests::it_converts_from_json" time="0" />
-    <testcase name="bindings::http_response::tests::it_is_empty_from_a_builder" time="0" />
-    <testcase name="bindings::queue_message::tests::it_converts_from_str" time="0" />
-    <testcase name="bindings::queue_message::tests::it_converts_from_string" time="0" />
-    <testcase name="bindings::queue_message::tests::it_converts_from_u8_slice" time="0" />
-    <testcase name="bindings::queue_message::tests::it_converts_from_u8_vec" time="0" />
-    <testcase name="bindings::queue_message::tests::it_converts_to_body" time="0" />
-    <testcase name="bindings::queue_message::tests::it_converts_to_json" time="0" />
-    <testcase name="bindings::queue_message::tests::it_converts_to_bytes" time="0" />
-    <testcase name="bindings::queue_message::tests::it_converts_to_string" time="0" />
-    <testcase name="bindings::queue_message::tests::it_converts_to_typed_data" time="0" />
-    <testcase name="bindings::queue_message::tests::it_has_bytes_content" time="0" />
-    <testcase name="bindings::queue_message::tests::it_displays_as_a_string" time="0" />
-    <testcase name="bindings::queue_message::tests::it_has_json_content" time="0" />
-    <testcase name="bindings::queue_trigger::tests::it_constructs" time="0" />
-    <testcase name="bindings::queue_message::tests::it_has_string_content" time="0" />
-    <testcase name="bindings::send_grid_message::tests::it_serializes_to_json" time="0" />
-    <testcase name="bindings::send_grid_message::tests::it_converts_to_typed_data" time="0" />
-    <testcase name="bindings::service_bus_message::tests::it_converts_from_json" time="0" />
-    <testcase name="bindings::service_bus_message::tests::it_converts_from_str" time="0" />
-    <testcase name="bindings::service_bus_message::tests::it_converts_from_string" time="0" />
-    <testcase name="bindings::service_bus_message::tests::it_converts_from_u8_vec" time="0" />
-    <testcase name="bindings::service_bus_message::tests::it_converts_from_u8_slice" time="0" />
-    <testcase name="bindings::service_bus_message::tests::it_converts_to_body" time="0" />
-    <testcase name="bindings::service_bus_message::tests::it_converts_to_bytes" time="0" />
-    <testcase name="bindings::service_bus_message::tests::it_converts_to_json" time="0" />
-    <testcase name="bindings::service_bus_message::tests::it_converts_to_string" time="0" />
-    <testcase name="bindings::service_bus_message::tests::it_converts_to_typed_data" time="0" />
-    <testcase name="bindings::service_bus_message::tests::it_has_bytes_content" time="0" />
-    <testcase name="bindings::service_bus_message::tests::it_displays_as_a_string" time="0" />
-    <testcase name="bindings::service_bus_message::tests::it_has_json_content" time="0" />
-    <testcase name="bindings::service_bus_trigger::tests::it_constructs" time="0" />
-    <testcase name="bindings::service_bus_message::tests::it_has_string_content" time="0" />
-    <testcase name="bindings::signalr_connection_info::tests::it_converts_from_typed_data" time="0" />
-    <testcase name="bindings::signalr_connection_info::tests::it_converts_to_body" time="0" />
-    <testcase name="bindings::signalr_group_action::tests::it_converts_to_typed_data" time="0" />
-    <testcase name="bindings::signalr_connection_info::tests::it_serializes_to_json" time="0" />
-    <testcase name="bindings::signalr_group_action::tests::it_serializes_to_json" time="0" />
-    <testcase name="bindings::signalr_message::tests::it_converts_to_typed_data" time="0" />
-    <testcase name="bindings::signalr_message::tests::it_serializes_to_json" time="0" />
-    <testcase name="bindings::table::tests::it_casts_to_value_reference" time="0" />
-    <testcase name="bindings::table::tests::it_adds_row_value" time="0" />
-    <testcase name="bindings::table::tests::it_constructs_an_empty_table" time="0" />
-    <testcase name="bindings::table::tests::it_converts_from_typed_data" time="0" />
-    <testcase name="bindings::table::tests::it_converts_to_body" time="0" />
-    <testcase name="bindings::table::tests::it_converts_to_json" time="0" />
-    <testcase name="bindings::table::tests::it_displays_as_a_string" time="0" />
-    <testcase name="bindings::table::tests::it_converts_to_typed_data" time="0" />
-    <testcase name="bindings::table::tests::it_has_a_length_equal_to_number_of_rows" time="0" />
-    <testcase name="bindings::table::tests::it_is_not_empty_when_rows_are_present" time="0" />
-    <testcase name="bindings::timer_info::tests::it_has_json_data" time="0" />
-    <testcase name="bindings::table::tests::it_iterates_rows" time="0" />
-    <testcase name="bindings::twilio_sms_message::tests::it_serializes_to_json" time="0" />
-    <testcase name="bindings::twilio_sms_message::tests::it_converts_to_typed_data" time="0" />
-    <testcase name="context::tests::it_returns_current_context" time="0" />
-    <testcase name="blob::properties::tests::it_deserializes_from_json" time="0" />
-    <testcase name="event_hub::partition_context::tests::it_deserializes_from_json" time="0" />
-    <testcase name="context::tests::it_returns_none_without_context" time="0" />
-    <testcase name="event_hub::system_properties::tests::it_deserializes_from_json" time="0" />
-    <testcase name="event_hub::runtime_information::tests::it_deserializes_from_json" time="0" />
-    <testcase name="generic::tests::it_converts_from_bytes_typed_data" time="0" />
-    <testcase name="generic::tests::it_converts_from_double_typed_data" time="0" />
-    <testcase name="generic::tests::it_converts_from_integer_typed_data" time="0" />
-    <testcase name="generic::tests::it_converts_from_json_typed_data" time="0" />
-    <testcase name="generic::tests::it_converts_from_no_typed_data" time="0" />
-    <testcase name="generic::tests::it_converts_from_stream_typed_data" time="0" />
-    <testcase name="generic::tests::it_converts_from_string_typed_data" time="0" />
-    <testcase name="generic::tests::it_converts_to_bytes_typed_data" time="0" />
-    <testcase name="generic::tests::it_converts_to_double_typed_data" time="0" />
-    <testcase name="generic::tests::it_converts_to_json_typed_data" time="0" />
-    <testcase name="generic::tests::it_converts_to_integer_typed_data" time="0" />
-    <testcase name="generic::tests::it_converts_to_no_typed_data" time="0" />
-    <testcase name="http::body::tests::it_converts_from_json" time="0" />
-    <testcase name="generic::tests::it_converts_to_string_typed_data" time="0" />
-    <testcase name="http::body::tests::it_converts_from_str" time="0" />
-    <testcase name="http::body::tests::it_converts_from_string" time="0" />
-    <testcase name="http::body::tests::it_converts_from_typed_data" time="0" />
-    <testcase name="http::body::tests::it_converts_from_u8_vec" time="0" />
-    <testcase name="http::body::tests::it_converts_from_u8_slice" time="0" />
-    <testcase name="http::body::tests::it_converts_to_typed_data" time="0" />
-    <testcase name="http::body::tests::it_has_a_bytes_body" time="0" />
-    <testcase name="http::body::tests::it_displays_as_a_string" time="0" />
-    <testcase name="http::body::tests::it_has_a_default_content_type" time="0" />
-    <testcase name="http::body::tests::it_has_a_json_body" time="0" />
-    <testcase name="http::body::tests::it_has_a_string_body" time="0" />
-    <testcase name="http::response_builder::tests::it_creates_an_empty_response" time="0" />
-    <testcase name="http::response_builder::tests::it_sets_a_body" time="0" />
-    <testcase name="http::response_builder::tests::it_sets_a_header" time="0" />
-    <testcase name="http::status::tests::it_converts_from_code" time="0" />
-    <testcase name="http::response_builder::tests::it_sets_a_status" time="0" />
-    <testcase name="http::status::tests::it_converts_to_string" time="0" />
-    <testcase name="registry::tests::it_builds_an_empty_extensions_map" time="0" />
-    <testcase name="registry::tests::it_builds_an_extensions_map" time="0" />
-    <testcase name="registry::tests::it_creates_a_registry_from_a_list_of_functions" time="0" />
-    <testcase name="registry::tests::it_creates_an_emptry_registry_from_an_empty_slice" time="0" />
-    <testcase name="registry::tests::it_registers_a_function" time="0" />
-    <testcase name="registry::tests::it_uses_the_latest_extension_version" time="0" />
-    <testcase name="registry::tests::it_returns_false_if_function_is_not_present" time="0" />
-    <testcase name="send_grid::bcc_settings::tests::it_serializes_to_json" time="0" />
-    <testcase name="send_grid::attachment::tests::it_serializes_to_json" time="0" />
-    <testcase name="send_grid::bypass_list_management::tests::it_serializes_to_json" time="0" />
-    <testcase name="send_grid::click_tracking::tests::it_serializes_to_json" time="0" />
-    <testcase name="send_grid::content::tests::it_serializes_to_json" time="0" />
-    <testcase name="send_grid::email_address::tests::it_serializes_to_json" time="0" />
-    <testcase name="send_grid::email_address::tests::it_converts_from_string" time="0" />
-    <testcase name="send_grid::footer_settings::tests::it_serializes_to_json" time="0" />
-    <testcase name="send_grid::google_analytics::tests::it_serializes_to_json" time="0" />
-    <testcase name="send_grid::mail_settings::tests::it_serializes_to_json" time="0" />
-    <testcase name="send_grid::open_tracking::tests::it_serializes_to_json" time="0" />
-    <testcase name="send_grid::sandbox_mode::tests::it_serializes_to_json" time="0" />
-    <testcase name="send_grid::personalization::tests::it_serializes_to_json" time="0" />
-    <testcase name="send_grid::subscription_tracking::tests::it_serializes_to_json" time="0" />
-    <testcase name="send_grid::spam_check::tests::it_serializes_to_json" time="0" />
-    <testcase name="send_grid::tracking_settings::tests::it_serializes_to_json" time="0" />
-    <testcase name="timer::schedule_status::tests::it_deserializes_from_json" time="0" />
-    <testcase name="send_grid::unsubscribe_group::tests::it_serializes_to_json" time="0" />
-    <testcase name="util::tests::it_converts_from_double_data" time="0" />
-    <testcase name="util::tests::it_converts_from_bytes_data" time="0" />
-    <testcase name="util::tests::it_converts_from_int_data" time="0" />
-    <testcase name="util::tests::it_converts_from_json_data" time="0" />
-    <testcase name="util::tests::it_converts_from_stream_data" time="0" />
-    <testcase name="util::tests::it_converts_from_string_data" time="0" />
-    <system-out />
-    <system-err />
+  <testsuite id="0" name="cargo test #0" package="testsuite/cargo test #0" tests="192" errors="0" failures="0" hostname="localhost" timestamp="2020-06-16T06:10:32.081394059+00:00" time="0">
+    <testcase name="it_converts_from_str" classname="bindings::blob::tests" time="0" />
+    <testcase name="it_converts_from_json" classname="bindings::blob::tests" time="0" />
+    <testcase name="it_converts_from_string" classname="bindings::blob::tests" time="0" />
+    <testcase name="it_converts_from_u8_slice" classname="bindings::blob::tests" time="0" />
+    <testcase name="it_converts_from_typed_data" classname="bindings::blob::tests" time="0" />
+    <testcase name="it_converts_from_u8_vec" classname="bindings::blob::tests" time="0" />
+    <testcase name="it_converts_to_body" classname="bindings::blob::tests" time="0" />
+    <testcase name="it_converts_to_json" classname="bindings::blob::tests" time="0" />
+    <testcase name="it_converts_to_bytes" classname="bindings::blob::tests" time="0" />
+    <testcase name="it_converts_to_string" classname="bindings::blob::tests" time="0" />
+    <testcase name="it_converts_to_typed_data" classname="bindings::blob::tests" time="0" />
+    <testcase name="it_displays_as_a_string" classname="bindings::blob::tests" time="0" />
+    <testcase name="it_has_json_content" classname="bindings::blob::tests" time="0" />
+    <testcase name="it_has_bytes_content" classname="bindings::blob::tests" time="0" />
+    <testcase name="it_has_string_content" classname="bindings::blob::tests" time="0" />
+    <testcase name="it_constructs_from_an_object_value" classname="bindings::cosmos_db_document::tests" time="0" />
+    <testcase name="it_constructs" classname="bindings::blob_trigger::tests" time="0" />
+    <testcase name="it_converts_from_str" classname="bindings::cosmos_db_document::tests" time="0" />
+    <testcase name="it_converts_from_string" classname="bindings::cosmos_db_document::tests" time="0" />
+    <testcase name="it_converts_from_value" classname="bindings::cosmos_db_document::tests" time="0" />
+    <testcase name="it_converts_from_typed_data" classname="bindings::cosmos_db_document::tests" time="0" />
+    <testcase name="it_converts_to_body" classname="bindings::cosmos_db_document::tests" time="0" />
+    <testcase name="it_converts_to_string" classname="bindings::cosmos_db_document::tests" time="0" />
+    <testcase name="it_converts_to_value" classname="bindings::cosmos_db_document::tests" time="0" />
+    <testcase name="it_displays_as_json" classname="bindings::cosmos_db_document::tests" time="0" />
+    <testcase name="it_converts_to_typed_data" classname="bindings::cosmos_db_document::tests" time="0" />
+    <testcase name="it_constructs" classname="bindings::cosmos_db_trigger::tests" time="0" />
+    <testcase name="it_panics_if_constructed_without_an_object_or_array" classname="bindings::cosmos_db_document::tests" time="0" />
+    <testcase name="it_converts_from_json" classname="bindings::event_hub_message::tests" time="0" />
+    <testcase name="it_constructs" classname="bindings::event_grid_event::tests" time="0" />
+    <testcase name="it_converts_from_str" classname="bindings::event_hub_message::tests" time="0" />
+    <testcase name="it_converts_from_string" classname="bindings::event_hub_message::tests" time="0" />
+    <testcase name="it_converts_from_u8_slice" classname="bindings::event_hub_message::tests" time="0" />
+    <testcase name="it_converts_to_body" classname="bindings::event_hub_message::tests" time="0" />
+    <testcase name="it_converts_from_u8_vec" classname="bindings::event_hub_message::tests" time="0" />
+    <testcase name="it_converts_to_bytes" classname="bindings::event_hub_message::tests" time="0" />
+    <testcase name="it_converts_to_json" classname="bindings::event_hub_message::tests" time="0" />
+    <testcase name="it_converts_to_string" classname="bindings::event_hub_message::tests" time="0" />
+    <testcase name="it_converts_to_typed_data" classname="bindings::event_hub_message::tests" time="0" />
+    <testcase name="it_displays_as_a_string" classname="bindings::event_hub_message::tests" time="0" />
+    <testcase name="it_has_bytes_content" classname="bindings::event_hub_message::tests" time="0" />
+    <testcase name="it_has_json_content" classname="bindings::event_hub_message::tests" time="0" />
+    <testcase name="it_has_string_content" classname="bindings::event_hub_message::tests" time="0" />
+    <testcase name="it_converts_from_typed_data" classname="bindings::generic_input::tests" time="0" />
+    <testcase name="it_constructs" classname="bindings::event_hub_trigger::tests" time="0" />
+    <testcase name="it_converts_from_double" classname="bindings::generic_output::tests" time="0" />
+    <testcase name="it_converts_from_bytes" classname="bindings::generic_output::tests" time="0" />
+    <testcase name="it_converts_from_integer" classname="bindings::generic_output::tests" time="0" />
+    <testcase name="it_converts_from_str" classname="bindings::generic_output::tests" time="0" />
+    <testcase name="it_converts_from_value" classname="bindings::generic_output::tests" time="0" />
+    <testcase name="it_converts_from_string" classname="bindings::generic_output::tests" time="0" />
+    <testcase name="it_converts_to_typed_data" classname="bindings::generic_output::tests" time="0" />
+    <testcase name="it_constructs" classname="bindings::generic_trigger::tests" time="0" />
+    <testcase name="it_has_a_header" classname="bindings::http_request::tests" time="0" />
+    <testcase name="it_has_a_bytes_body" classname="bindings::http_request::tests" time="0" />
+    <testcase name="it_has_a_json_body" classname="bindings::http_request::tests" time="0" />
+    <testcase name="it_has_a_query_parameter" classname="bindings::http_request::tests" time="0" />
+    <testcase name="it_has_a_stream_body" classname="bindings::http_request::tests" time="0" />
+    <testcase name="it_has_a_route_parameter" classname="bindings::http_request::tests" time="0" />
+    <testcase name="it_has_a_string_body" classname="bindings::http_request::tests" time="0" />
+    <testcase name="it_has_an_empty_body" classname="bindings::http_request::tests" time="0" />
+    <testcase name="it_has_the_url" classname="bindings::http_request::tests" time="0" />
+    <testcase name="it_has_the_method" classname="bindings::http_request::tests" time="0" />
+    <testcase name="it_builds_with_a_bytes_body" classname="bindings::http_response::tests" time="0" />
+    <testcase name="it_builds_with_a_json_body" classname="bindings::http_response::tests" time="0" />
+    <testcase name="it_builds_with_a_status" classname="bindings::http_response::tests" time="0" />
+    <testcase name="it_builds_with_a_string_body" classname="bindings::http_response::tests" time="0" />
+    <testcase name="it_builds_with_headers" classname="bindings::http_response::tests" time="0" />
+    <testcase name="it_converts_to_typed_data" classname="bindings::http_response::tests" time="0" />
+    <testcase name="it_is_empty_by_default" classname="bindings::http_response::tests" time="0" />
+    <testcase name="it_converts_from_json" classname="bindings::queue_message::tests" time="0" />
+    <testcase name="it_is_empty_from_a_builder" classname="bindings::http_response::tests" time="0" />
+    <testcase name="it_converts_from_str" classname="bindings::queue_message::tests" time="0" />
+    <testcase name="it_converts_from_string" classname="bindings::queue_message::tests" time="0" />
+    <testcase name="it_converts_from_u8_slice" classname="bindings::queue_message::tests" time="0" />
+    <testcase name="it_converts_from_u8_vec" classname="bindings::queue_message::tests" time="0" />
+    <testcase name="it_converts_to_body" classname="bindings::queue_message::tests" time="0" />
+    <testcase name="it_converts_to_json" classname="bindings::queue_message::tests" time="0" />
+    <testcase name="it_converts_to_bytes" classname="bindings::queue_message::tests" time="0" />
+    <testcase name="it_converts_to_string" classname="bindings::queue_message::tests" time="0" />
+    <testcase name="it_converts_to_typed_data" classname="bindings::queue_message::tests" time="0" />
+    <testcase name="it_has_bytes_content" classname="bindings::queue_message::tests" time="0" />
+    <testcase name="it_displays_as_a_string" classname="bindings::queue_message::tests" time="0" />
+    <testcase name="it_has_json_content" classname="bindings::queue_message::tests" time="0" />
+    <testcase name="it_constructs" classname="bindings::queue_trigger::tests" time="0" />
+    <testcase name="it_has_string_content" classname="bindings::queue_message::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="bindings::send_grid_message::tests" time="0" />
+    <testcase name="it_converts_to_typed_data" classname="bindings::send_grid_message::tests" time="0" />
+    <testcase name="it_converts_from_json" classname="bindings::service_bus_message::tests" time="0" />
+    <testcase name="it_converts_from_str" classname="bindings::service_bus_message::tests" time="0" />
+    <testcase name="it_converts_from_string" classname="bindings::service_bus_message::tests" time="0" />
+    <testcase name="it_converts_from_u8_vec" classname="bindings::service_bus_message::tests" time="0" />
+    <testcase name="it_converts_from_u8_slice" classname="bindings::service_bus_message::tests" time="0" />
+    <testcase name="it_converts_to_body" classname="bindings::service_bus_message::tests" time="0" />
+    <testcase name="it_converts_to_bytes" classname="bindings::service_bus_message::tests" time="0" />
+    <testcase name="it_converts_to_json" classname="bindings::service_bus_message::tests" time="0" />
+    <testcase name="it_converts_to_string" classname="bindings::service_bus_message::tests" time="0" />
+    <testcase name="it_converts_to_typed_data" classname="bindings::service_bus_message::tests" time="0" />
+    <testcase name="it_has_bytes_content" classname="bindings::service_bus_message::tests" time="0" />
+    <testcase name="it_displays_as_a_string" classname="bindings::service_bus_message::tests" time="0" />
+    <testcase name="it_has_json_content" classname="bindings::service_bus_message::tests" time="0" />
+    <testcase name="it_constructs" classname="bindings::service_bus_trigger::tests" time="0" />
+    <testcase name="it_has_string_content" classname="bindings::service_bus_message::tests" time="0" />
+    <testcase name="it_converts_from_typed_data" classname="bindings::signalr_connection_info::tests" time="0" />
+    <testcase name="it_converts_to_body" classname="bindings::signalr_connection_info::tests" time="0" />
+    <testcase name="it_converts_to_typed_data" classname="bindings::signalr_group_action::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="bindings::signalr_connection_info::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="bindings::signalr_group_action::tests" time="0" />
+    <testcase name="it_converts_to_typed_data" classname="bindings::signalr_message::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="bindings::signalr_message::tests" time="0" />
+    <testcase name="it_casts_to_value_reference" classname="bindings::table::tests" time="0" />
+    <testcase name="it_adds_row_value" classname="bindings::table::tests" time="0" />
+    <testcase name="it_constructs_an_empty_table" classname="bindings::table::tests" time="0" />
+    <testcase name="it_converts_from_typed_data" classname="bindings::table::tests" time="0" />
+    <testcase name="it_converts_to_body" classname="bindings::table::tests" time="0" />
+    <testcase name="it_converts_to_json" classname="bindings::table::tests" time="0" />
+    <testcase name="it_displays_as_a_string" classname="bindings::table::tests" time="0" />
+    <testcase name="it_converts_to_typed_data" classname="bindings::table::tests" time="0" />
+    <testcase name="it_has_a_length_equal_to_number_of_rows" classname="bindings::table::tests" time="0" />
+    <testcase name="it_is_not_empty_when_rows_are_present" classname="bindings::table::tests" time="0" />
+    <testcase name="it_has_json_data" classname="bindings::timer_info::tests" time="0" />
+    <testcase name="it_iterates_rows" classname="bindings::table::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="bindings::twilio_sms_message::tests" time="0" />
+    <testcase name="it_converts_to_typed_data" classname="bindings::twilio_sms_message::tests" time="0" />
+    <testcase name="it_returns_current_context" classname="context::tests" time="0" />
+    <testcase name="it_deserializes_from_json" classname="blob::properties::tests" time="0" />
+    <testcase name="it_deserializes_from_json" classname="event_hub::partition_context::tests" time="0" />
+    <testcase name="it_returns_none_without_context" classname="context::tests" time="0" />
+    <testcase name="it_deserializes_from_json" classname="event_hub::system_properties::tests" time="0" />
+    <testcase name="it_deserializes_from_json" classname="event_hub::runtime_information::tests" time="0" />
+    <testcase name="it_converts_from_bytes_typed_data" classname="generic::tests" time="0" />
+    <testcase name="it_converts_from_double_typed_data" classname="generic::tests" time="0" />
+    <testcase name="it_converts_from_integer_typed_data" classname="generic::tests" time="0" />
+    <testcase name="it_converts_from_json_typed_data" classname="generic::tests" time="0" />
+    <testcase name="it_converts_from_no_typed_data" classname="generic::tests" time="0" />
+    <testcase name="it_converts_from_stream_typed_data" classname="generic::tests" time="0" />
+    <testcase name="it_converts_from_string_typed_data" classname="generic::tests" time="0" />
+    <testcase name="it_converts_to_bytes_typed_data" classname="generic::tests" time="0" />
+    <testcase name="it_converts_to_double_typed_data" classname="generic::tests" time="0" />
+    <testcase name="it_converts_to_json_typed_data" classname="generic::tests" time="0" />
+    <testcase name="it_converts_to_integer_typed_data" classname="generic::tests" time="0" />
+    <testcase name="it_converts_to_no_typed_data" classname="generic::tests" time="0" />
+    <testcase name="it_converts_from_json" classname="http::body::tests" time="0" />
+    <testcase name="it_converts_to_string_typed_data" classname="generic::tests" time="0" />
+    <testcase name="it_converts_from_str" classname="http::body::tests" time="0" />
+    <testcase name="it_converts_from_string" classname="http::body::tests" time="0" />
+    <testcase name="it_converts_from_typed_data" classname="http::body::tests" time="0" />
+    <testcase name="it_converts_from_u8_vec" classname="http::body::tests" time="0" />
+    <testcase name="it_converts_from_u8_slice" classname="http::body::tests" time="0" />
+    <testcase name="it_converts_to_typed_data" classname="http::body::tests" time="0" />
+    <testcase name="it_has_a_bytes_body" classname="http::body::tests" time="0" />
+    <testcase name="it_displays_as_a_string" classname="http::body::tests" time="0" />
+    <testcase name="it_has_a_default_content_type" classname="http::body::tests" time="0" />
+    <testcase name="it_has_a_json_body" classname="http::body::tests" time="0" />
+    <testcase name="it_has_a_string_body" classname="http::body::tests" time="0" />
+    <testcase name="it_creates_an_empty_response" classname="http::response_builder::tests" time="0" />
+    <testcase name="it_sets_a_body" classname="http::response_builder::tests" time="0" />
+    <testcase name="it_sets_a_header" classname="http::response_builder::tests" time="0" />
+    <testcase name="it_converts_from_code" classname="http::status::tests" time="0" />
+    <testcase name="it_sets_a_status" classname="http::response_builder::tests" time="0" />
+    <testcase name="it_converts_to_string" classname="http::status::tests" time="0" />
+    <testcase name="it_builds_an_empty_extensions_map" classname="registry::tests" time="0" />
+    <testcase name="it_builds_an_extensions_map" classname="registry::tests" time="0" />
+    <testcase name="it_creates_a_registry_from_a_list_of_functions" classname="registry::tests" time="0" />
+    <testcase name="it_creates_an_emptry_registry_from_an_empty_slice" classname="registry::tests" time="0" />
+    <testcase name="it_registers_a_function" classname="registry::tests" time="0" />
+    <testcase name="it_uses_the_latest_extension_version" classname="registry::tests" time="0" />
+    <testcase name="it_returns_false_if_function_is_not_present" classname="registry::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="send_grid::bcc_settings::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="send_grid::attachment::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="send_grid::bypass_list_management::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="send_grid::click_tracking::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="send_grid::content::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="send_grid::email_address::tests" time="0" />
+    <testcase name="it_converts_from_string" classname="send_grid::email_address::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="send_grid::footer_settings::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="send_grid::google_analytics::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="send_grid::mail_settings::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="send_grid::open_tracking::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="send_grid::sandbox_mode::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="send_grid::personalization::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="send_grid::subscription_tracking::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="send_grid::spam_check::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="send_grid::tracking_settings::tests" time="0" />
+    <testcase name="it_deserializes_from_json" classname="timer::schedule_status::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="send_grid::unsubscribe_group::tests" time="0" />
+    <testcase name="it_converts_from_double_data" classname="util::tests" time="0" />
+    <testcase name="it_converts_from_bytes_data" classname="util::tests" time="0" />
+    <testcase name="it_converts_from_int_data" classname="util::tests" time="0" />
+    <testcase name="it_converts_from_json_data" classname="util::tests" time="0" />
+    <testcase name="it_converts_from_stream_data" classname="util::tests" time="0" />
+    <testcase name="it_converts_from_string_data" classname="util::tests" time="0" />
   </testsuite>
-  <testsuite id="1" name="cargo test #1" package="testsuite/cargo test #1" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:05.997283800+00:00" time="0">
-    <system-out />
-    <system-err />
+  <testsuite id="1" name="cargo test #1" package="testsuite/cargo test #1" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-16T06:10:32.081394059+00:00" time="0" />
+  <testsuite id="2" name="cargo test #2" package="testsuite/cargo test #2" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-16T06:10:32.081394059+00:00" time="0" />
+  <testsuite id="3" name="cargo test #3" package="testsuite/cargo test #3" tests="205" errors="0" failures="0" hostname="localhost" timestamp="2020-06-16T06:10:32.081394059+00:00" time="0">
+    <testcase name="it_converts_to_tokens" classname="codegen::bindings::blob::tests" time="0" />
+    <testcase name="it_parses_attribute_arguments" classname="codegen::bindings::blob::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_argument" classname="codegen::bindings::blob::tests" time="0" />
+    <testcase name="it_requires_the_connection_attribute_be_a_string" classname="codegen::bindings::blob::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_be_a_string" classname="codegen::bindings::blob::tests" time="0" />
+    <testcase name="it_requires_the_path_attribute_argument" classname="codegen::bindings::blob::tests" time="0" />
+    <testcase name="it_requires_the_path_attribute_be_a_string" classname="codegen::bindings::blob::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="codegen::bindings::blob::tests" time="0" />
+    <testcase name="it_converts_to_tokens" classname="codegen::bindings::blob_trigger::tests" time="0" />
+    <testcase name="it_requires_the_connection_attribute_be_a_string" classname="codegen::bindings::blob_trigger::tests" time="0" />
+    <testcase name="it_parses_attribute_arguments" classname="codegen::bindings::blob_trigger::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_be_a_string" classname="codegen::bindings::blob_trigger::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_argument" classname="codegen::bindings::blob_trigger::tests" time="0" />
+    <testcase name="it_requires_the_path_attribute_argument" classname="codegen::bindings::blob_trigger::tests" time="0" />
+    <testcase name="it_requires_the_path_attribute_be_a_string" classname="codegen::bindings::blob_trigger::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="codegen::bindings::blob_trigger::tests" time="0" />
+    <testcase name="it_parses_attribute_arguments" classname="codegen::bindings::cosmos_db::tests" time="0" />
+    <testcase name="it_converts_to_tokens" classname="codegen::bindings::cosmos_db::tests" time="0" />
+    <testcase name="it_requires_the_collection_name_attribute_argument" classname="codegen::bindings::cosmos_db::tests" time="0" />
+    <testcase name="it_requires_the_collection_name_attribute_be_a_string" classname="codegen::bindings::cosmos_db::tests" time="0" />
+    <testcase name="it_requires_the_collection_throughput_attribute_be_an_integer" classname="codegen::bindings::cosmos_db::tests" time="0" />
+    <testcase name="it_requires_the_connection_attribute_be_a_string" classname="codegen::bindings::cosmos_db::tests" time="0" />
+    <testcase name="it_requires_the_connection_attribute_argument" classname="codegen::bindings::cosmos_db::tests" time="0" />
+    <testcase name="it_requires_the_create_collection_attribute_be_a_bool" classname="codegen::bindings::cosmos_db::tests" time="0" />
+    <testcase name="it_requires_the_database_name_attribute_argument" classname="codegen::bindings::cosmos_db::tests" time="0" />
+    <testcase name="it_requires_the_database_name_attribute_be_a_string" classname="codegen::bindings::cosmos_db::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_argument" classname="codegen::bindings::cosmos_db::tests" time="0" />
+    <testcase name="it_requires_the_id_attribute_be_a_string" classname="codegen::bindings::cosmos_db::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_be_a_string" classname="codegen::bindings::cosmos_db::tests" time="0" />
+    <testcase name="it_requires_the_partition_key_attribute_be_a_string" classname="codegen::bindings::cosmos_db::tests" time="0" />
+    <testcase name="it_requires_the_sql_query_attribute_be_a_string" classname="codegen::bindings::cosmos_db::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="codegen::bindings::cosmos_db::tests" time="0" />
+    <testcase name="it_converts_to_tokens" classname="codegen::bindings::cosmos_db_trigger::tests" time="0" />
+    <testcase name="it_requires_the_checkpoint_frequency_attribute_be_an_integer" classname="codegen::bindings::cosmos_db_trigger::tests" time="0" />
+    <testcase name="it_parses_attribute_arguments" classname="codegen::bindings::cosmos_db_trigger::tests" time="0" />
+    <testcase name="it_requires_the_collection_name_attribute_be_a_string" classname="codegen::bindings::cosmos_db_trigger::tests" time="0" />
+    <testcase name="it_requires_the_collection_name_attribute_argument" classname="codegen::bindings::cosmos_db_trigger::tests" time="0" />
+    <testcase name="it_requires_the_connection_attribute_argument" classname="codegen::bindings::cosmos_db_trigger::tests" time="0" />
+    <testcase name="it_requires_the_connection_attribute_be_a_string" classname="codegen::bindings::cosmos_db_trigger::tests" time="0" />
+    <testcase name="it_requires_the_create_lease_collection_attribute_be_a_boolean" classname="codegen::bindings::cosmos_db_trigger::tests" time="0" />
+    <testcase name="it_requires_the_database_name_attribute_argument" classname="codegen::bindings::cosmos_db_trigger::tests" time="0" />
+    <testcase name="it_requires_the_feed_poll_delay_attribute_be_an_integer" classname="codegen::bindings::cosmos_db_trigger::tests" time="0" />
+    <testcase name="it_requires_the_database_name_attribute_be_a_string" classname="codegen::bindings::cosmos_db_trigger::tests" time="0" />
+    <testcase name="it_requires_the_lease_collection_prefix_attribute_be_a_string" classname="codegen::bindings::cosmos_db_trigger::tests" time="0" />
+    <testcase name="it_requires_the_lease_acquire_interval_attribute_be_an_integer" classname="codegen::bindings::cosmos_db_trigger::tests" time="0" />
+    <testcase name="it_requires_the_lease_collection_throughput_attribute_be_an_integer" classname="codegen::bindings::cosmos_db_trigger::tests" time="0" />
+    <testcase name="it_requires_the_lease_connection_attribute_be_a_string" classname="codegen::bindings::cosmos_db_trigger::tests" time="0" />
+    <testcase name="it_requires_the_lease_renew_interval_attribute_be_an_integer" classname="codegen::bindings::cosmos_db_trigger::tests" time="0" />
+    <testcase name="it_requires_the_lease_expiration_interval_attribute_be_an_integer" classname="codegen::bindings::cosmos_db_trigger::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_argument" classname="codegen::bindings::cosmos_db_trigger::tests" time="0" />
+    <testcase name="it_requires_the_max_items_per_invocation_attribute_be_an_integer" classname="codegen::bindings::cosmos_db_trigger::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_be_a_string" classname="codegen::bindings::cosmos_db_trigger::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="codegen::bindings::cosmos_db_trigger::tests" time="0" />
+    <testcase name="it_requires_the_start_from_beginning_attribute_be_a_boolean" classname="codegen::bindings::cosmos_db_trigger::tests" time="0" />
+    <testcase name="it_converts_to_tokens" classname="codegen::bindings::event_grid_trigger::tests" time="0" />
+    <testcase name="it_parses_attribute_arguments" classname="codegen::bindings::event_grid_trigger::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_argument" classname="codegen::bindings::event_grid_trigger::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_be_a_string" classname="codegen::bindings::event_grid_trigger::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="codegen::bindings::event_grid_trigger::tests" time="0" />
+    <testcase name="it_parses_attribute_arguments" classname="codegen::bindings::event_hub::tests" time="0" />
+    <testcase name="it_converts_to_tokens" classname="codegen::bindings::event_hub::tests" time="0" />
+    <testcase name="it_requires_the_connection_attribute_argument" classname="codegen::bindings::event_hub::tests" time="0" />
+    <testcase name="it_requires_the_connection_attribute_be_a_string" classname="codegen::bindings::event_hub::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_argument" classname="codegen::bindings::event_hub::tests" time="0" />
+    <testcase name="it_requires_the_event_hub_name_attribute_be_a_string" classname="codegen::bindings::event_hub::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_be_a_string" classname="codegen::bindings::event_hub::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="codegen::bindings::event_hub::tests" time="0" />
+    <testcase name="it_parses_attribute_arguments" classname="codegen::bindings::event_hub_trigger::tests" time="0" />
+    <testcase name="it_converts_to_tokens" classname="codegen::bindings::event_hub_trigger::tests" time="0" />
+    <testcase name="it_requires_the_connection_attribute_argument" classname="codegen::bindings::event_hub_trigger::tests" time="0" />
+    <testcase name="it_requires_the_consumer_group_attribute_be_a_string" classname="codegen::bindings::event_hub_trigger::tests" time="0" />
+    <testcase name="it_requires_the_connection_attribute_be_a_string" classname="codegen::bindings::event_hub_trigger::tests" time="0" />
+    <testcase name="it_requires_the_event_hub_name_attribute_be_a_string" classname="codegen::bindings::event_hub_trigger::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_argument" classname="codegen::bindings::event_hub_trigger::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_be_a_string" classname="codegen::bindings::event_hub_trigger::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="codegen::bindings::event_hub_trigger::tests" time="0" />
+    <testcase name="it_converts_to_tokens" classname="codegen::bindings::generic::tests" time="0" />
+    <testcase name="it_parses_attribute_arguments" classname="codegen::bindings::generic::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_argument" classname="codegen::bindings::generic::tests" time="0" />
+    <testcase name="it_requires_the_type_attribute_argument" classname="codegen::bindings::generic::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_be_a_string" classname="codegen::bindings::generic::tests" time="0" />
+    <testcase name="it_requires_the_type_attribute_be_a_string" classname="codegen::bindings::generic::tests" time="0" />
+    <testcase name="it_converts_to_tokens" classname="codegen::bindings::http::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="codegen::bindings::generic::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_argument" classname="codegen::bindings::http::tests" time="0" />
+    <testcase name="it_parses_attribute_arguments" classname="codegen::bindings::http::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_be_a_string" classname="codegen::bindings::http::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="codegen::bindings::http::tests" time="0" />
+    <testcase name="it_accepts_valid_methods" classname="codegen::bindings::http_trigger::tests" time="0" />
+    <testcase name="it_accepts_valid_auth_levels" classname="codegen::bindings::http_trigger::tests" time="0" />
+    <testcase name="it_converts_to_tokens" classname="codegen::bindings::http_trigger::tests" time="0" />
+    <testcase name="it_rejects_invalid_auth_levels" classname="codegen::bindings::http_trigger::tests" time="0" />
+    <testcase name="it_parses_attribute_arguments" classname="codegen::bindings::http_trigger::tests" time="0" />
+    <testcase name="it_requires_the_auth_level_attribute_be_a_string" classname="codegen::bindings::http_trigger::tests" time="0" />
+    <testcase name="it_rejects_invalid_methods" classname="codegen::bindings::http_trigger::tests" time="0" />
+    <testcase name="it_requires_the_methods_attribute_be_a_string" classname="codegen::bindings::http_trigger::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_argument" classname="codegen::bindings::http_trigger::tests" time="0" />
+    <testcase name="it_requires_the_route_attribute_be_a_string" classname="codegen::bindings::http_trigger::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_be_a_string" classname="codegen::bindings::http_trigger::tests" time="0" />
+    <testcase name="it_converts_to_tokens" classname="codegen::bindings::queue::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="codegen::bindings::http_trigger::tests" time="0" />
+    <testcase name="it_parses_attribute_arguments" classname="codegen::bindings::queue::tests" time="0" />
+    <testcase name="it_requires_the_connection_attribute_be_a_string" classname="codegen::bindings::queue::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_be_a_string" classname="codegen::bindings::queue::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_argument" classname="codegen::bindings::queue::tests" time="0" />
+    <testcase name="it_requires_the_queue_name_attribute_be_a_string" classname="codegen::bindings::queue::tests" time="0" />
+    <testcase name="it_requires_the_queue_name_attribute_argument" classname="codegen::bindings::queue::tests" time="0" />
+    <testcase name="it_converts_to_tokens" classname="codegen::bindings::queue_trigger::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="codegen::bindings::queue::tests" time="0" />
+    <testcase name="it_requires_the_connection_attribute_be_a_string" classname="codegen::bindings::queue_trigger::tests" time="0" />
+    <testcase name="it_parses_attribute_arguments" classname="codegen::bindings::queue_trigger::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_be_a_string" classname="codegen::bindings::queue_trigger::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_argument" classname="codegen::bindings::queue_trigger::tests" time="0" />
+    <testcase name="it_requires_the_queue_name_attribute_be_a_string" classname="codegen::bindings::queue_trigger::tests" time="0" />
+    <testcase name="it_requires_the_queue_name_attribute_argument" classname="codegen::bindings::queue_trigger::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="codegen::bindings::queue_trigger::tests" time="0" />
+    <testcase name="it_converts_to_tokens" classname="codegen::bindings::send_grid::tests" time="0" />
+    <testcase name="it_requires_the_api_key_attribute_be_a_string" classname="codegen::bindings::send_grid::tests" time="0" />
+    <testcase name="it_parses_attribute_arguments" classname="codegen::bindings::send_grid::tests" time="0" />
+    <testcase name="it_requires_the_from_attribute_be_a_string" classname="codegen::bindings::send_grid::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_argument" classname="codegen::bindings::send_grid::tests" time="0" />
+    <testcase name="it_requires_the_subject_attribute_be_a_string" classname="codegen::bindings::send_grid::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_be_a_string" classname="codegen::bindings::send_grid::tests" time="0" />
+    <testcase name="it_requires_the_text_attribute_be_a_string" classname="codegen::bindings::send_grid::tests" time="0" />
+    <testcase name="it_requires_the_to_attribute_be_a_string" classname="codegen::bindings::send_grid::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="codegen::bindings::send_grid::tests" time="0" />
+    <testcase name="it_converts_to_tokens" classname="codegen::bindings::service_bus::tests" time="0" />
+    <testcase name="it_requires_queue_name_or_topic_subscription" classname="codegen::bindings::service_bus::tests" time="0" />
+    <testcase name="it_parses_attribute_arguments" classname="codegen::bindings::service_bus::tests" time="0" />
+    <testcase name="it_requires_the_connection_attribute_be_a_string" classname="codegen::bindings::service_bus::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_argument" classname="codegen::bindings::service_bus::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_be_a_string" classname="codegen::bindings::service_bus::tests" time="0" />
+    <testcase name="it_requires_the_queue_name_attribute_be_a_string" classname="codegen::bindings::service_bus::tests" time="0" />
+    <testcase name="it_requires_the_topic_name_attribute_be_a_string" classname="codegen::bindings::service_bus::tests" time="0" />
+    <testcase name="it_requires_the_subscription_name_attribute_be_a_string" classname="codegen::bindings::service_bus::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="codegen::bindings::service_bus::tests" time="0" />
+    <testcase name="it_converts_to_tokens" classname="codegen::bindings::service_bus_trigger::tests" time="0" />
+    <testcase name="it_parses_attribute_arguments" classname="codegen::bindings::service_bus_trigger::tests" time="0" />
+    <testcase name="it_requires_queue_name_or_topic_subscription" classname="codegen::bindings::service_bus_trigger::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_argument" classname="codegen::bindings::service_bus_trigger::tests" time="0" />
+    <testcase name="it_requires_the_connection_attribute_be_a_string" classname="codegen::bindings::service_bus_trigger::tests" time="0" />
+    <testcase name="it_requires_the_queue_name_attribute_be_a_string" classname="codegen::bindings::service_bus_trigger::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_be_a_string" classname="codegen::bindings::service_bus_trigger::tests" time="0" />
+    <testcase name="it_requires_the_topic_name_attribute_be_a_string" classname="codegen::bindings::service_bus_trigger::tests" time="0" />
+    <testcase name="it_requires_the_subscription_name_attribute_be_a_string" classname="codegen::bindings::service_bus_trigger::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="codegen::bindings::service_bus_trigger::tests" time="0" />
+    <testcase name="it_converts_to_tokens" classname="codegen::bindings::signalr::tests" time="0" />
+    <testcase name="it_parses_attribute_arguments" classname="codegen::bindings::signalr::tests" time="0" />
+    <testcase name="it_requires_the_connection_attribute_be_a_string" classname="codegen::bindings::signalr::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_argument" classname="codegen::bindings::signalr::tests" time="0" />
+    <testcase name="it_requires_the_hub_name_attribute_argument" classname="codegen::bindings::signalr::tests" time="0" />
+    <testcase name="it_requires_the_queue_name_attribute_be_a_string" classname="codegen::bindings::signalr::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_be_a_string" classname="codegen::bindings::signalr::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="codegen::bindings::signalr::tests" time="0" />
+    <testcase name="it_converts_to_tokens" classname="codegen::bindings::signalr_connection_info::tests" time="0" />
+    <testcase name="it_parses_attribute_arguments" classname="codegen::bindings::signalr_connection_info::tests" time="0" />
+    <testcase name="it_requires_the_connection_attribute_be_a_string" classname="codegen::bindings::signalr_connection_info::tests" time="0" />
+    <testcase name="it_requires_the_hub_name_attribute_argument" classname="codegen::bindings::signalr_connection_info::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_be_a_string" classname="codegen::bindings::signalr_connection_info::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_argument" classname="codegen::bindings::signalr_connection_info::tests" time="0" />
+    <testcase name="it_requires_the_queue_name_attribute_be_a_string" classname="codegen::bindings::signalr_connection_info::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="codegen::bindings::signalr_connection_info::tests" time="0" />
+    <testcase name="it_requires_the_user_id_attribute_be_a_string" classname="codegen::bindings::signalr_connection_info::tests" time="0" />
+    <testcase name="it_parses_attribute_arguments" classname="codegen::bindings::table::tests" time="0" />
+    <testcase name="it_converts_to_tokens" classname="codegen::bindings::table::tests" time="0" />
+    <testcase name="it_requires_the_connection_attribute_be_a_string" classname="codegen::bindings::table::tests" time="0" />
+    <testcase name="it_requires_the_filter_be_a_string" classname="codegen::bindings::table::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_be_a_string" classname="codegen::bindings::table::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_argument" classname="codegen::bindings::table::tests" time="0" />
+    <testcase name="it_requires_the_row_key_attribute_be_a_string" classname="codegen::bindings::table::tests" time="0" />
+    <testcase name="it_requires_the_partition_key_attribute_be_a_string" classname="codegen::bindings::table::tests" time="0" />
+    <testcase name="it_requires_the_table_name_attribute_be_a_string" classname="codegen::bindings::table::tests" time="0" />
+    <testcase name="it_requires_the_table_name_attribute_argument" classname="codegen::bindings::table::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="codegen::bindings::table::tests" time="0" />
+    <testcase name="it_requires_the_take_attribute_be_a_string" classname="codegen::bindings::table::tests" time="0" />
+    <testcase name="it_parses_attribute_arguments" classname="codegen::bindings::timer_trigger::tests" time="0" />
+    <testcase name="it_converts_to_tokens" classname="codegen::bindings::timer_trigger::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_be_a_string" classname="codegen::bindings::timer_trigger::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_argument" classname="codegen::bindings::timer_trigger::tests" time="0" />
+    <testcase name="it_requires_the_run_on_startup_attribute_be_a_bool" classname="codegen::bindings::timer_trigger::tests" time="0" />
+    <testcase name="it_requires_the_schedule_attribute_argument" classname="codegen::bindings::timer_trigger::tests" time="0" />
+    <testcase name="it_requires_the_schedule_attribute_be_a_string" classname="codegen::bindings::timer_trigger::tests" time="0" />
+    <testcase name="it_requires_the_use_monitor_attribute_be_a_bool" classname="codegen::bindings::timer_trigger::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="codegen::bindings::timer_trigger::tests" time="0" />
+    <testcase name="it_converts_to_tokens" classname="codegen::bindings::twilio_sms::tests" time="0" />
+    <testcase name="it_requires_the_account_sid_attribute_be_a_string" classname="codegen::bindings::twilio_sms::tests" time="0" />
+    <testcase name="it_parses_attribute_arguments" classname="codegen::bindings::twilio_sms::tests" time="0" />
+    <testcase name="it_requires_the_body_attribute_be_a_string" classname="codegen::bindings::twilio_sms::tests" time="0" />
+    <testcase name="it_requires_the_auth_token_attribute_be_a_string" classname="codegen::bindings::twilio_sms::tests" time="0" />
+    <testcase name="it_requires_the_from_attribute_be_a_string" classname="codegen::bindings::twilio_sms::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_be_a_string" classname="codegen::bindings::twilio_sms::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_argument" classname="codegen::bindings::twilio_sms::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="codegen::bindings::twilio_sms::tests" time="0" />
+    <testcase name="it_parses_attribute_arguments" classname="codegen::function::tests" time="0" />
+    <testcase name="it_converts_to_tokens" classname="codegen::function::tests" time="0" />
+    <testcase name="it_requires_an_identifier_for_name" classname="codegen::function::tests" time="0" />
+    <testcase name="it_requires_the_disabled_attribute_be_a_boolean" classname="codegen::function::tests" time="0" />
+    <testcase name="it_serializes_to_json" classname="codegen::function::tests" time="0" />
+    <testcase name="it_requires_the_name_attribute_be_a_string" classname="codegen::function::tests" time="0" />
+    <testcase name="it_converts_boolean_to_tokens" classname="codegen::value::tests" time="0" />
+    <testcase name="it_converts_integer_to_tokens" classname="codegen::value::tests" time="0" />
+    <testcase name="it_serializes_boolean_to_json" classname="codegen::value::tests" time="0" />
+    <testcase name="it_converts_string_to_tokens" classname="codegen::value::tests" time="0" />
+    <testcase name="it_serializes_string_to_json" classname="codegen::value::tests" time="0" />
+    <testcase name="it_serializes_integer_to_json" classname="codegen::value::tests" time="0" />
   </testsuite>
-  <testsuite id="2" name="cargo test #2" package="testsuite/cargo test #2" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:05.997283800+00:00" time="0">
-    <system-out />
-    <system-err />
+  <testsuite id="4" name="cargo test #4" package="testsuite/cargo test #4" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-16T06:10:32.081394059+00:00" time="0" />
+  <testsuite id="5" name="cargo test #5" package="testsuite/cargo test #5" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-16T06:10:32.081394059+00:00" time="0" />
+  <testsuite id="6" name="cargo test #6" package="testsuite/cargo test #6" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-16T06:10:32.081394059+00:00" time="0" />
+  <testsuite id="7" name="cargo test #7" package="testsuite/cargo test #7" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-16T06:10:32.081394059+00:00" time="0" />
+  <testsuite id="8" name="cargo test #8" package="testsuite/cargo test #8" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-16T06:10:32.081394059+00:00" time="0" />
+  <testsuite id="9" name="cargo test #9" package="testsuite/cargo test #9" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-16T06:10:32.081394059+00:00" time="0" />
+  <testsuite id="10" name="cargo test #10" package="testsuite/cargo test #10" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-16T06:10:32.081394059+00:00" time="0" />
+  <testsuite id="11" name="cargo test #11" package="testsuite/cargo test #11" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-16T06:10:32.081394059+00:00" time="0" />
+  <testsuite id="12" name="cargo test #12" package="testsuite/cargo test #12" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-16T06:10:32.081394059+00:00" time="0" />
+  <testsuite id="13" name="cargo test #13" package="testsuite/cargo test #13" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-16T06:10:32.081394059+00:00" time="0" />
+  <testsuite id="14" name="cargo test #14" package="testsuite/cargo test #14" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-16T06:10:32.081394059+00:00" time="0" />
+  <testsuite id="15" name="cargo test #15" package="testsuite/cargo test #15" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-16T06:10:32.081394059+00:00" time="0" />
+  <testsuite id="16" name="cargo test #16" package="testsuite/cargo test #16" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-16T06:10:32.081394059+00:00" time="0" />
+  <testsuite id="17" name="cargo test #17" package="testsuite/cargo test #17" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-16T06:10:32.081394059+00:00" time="0" />
+  <testsuite id="18" name="cargo test #18" package="testsuite/cargo test #18" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-16T06:10:32.081394059+00:00" time="0" />
+  <testsuite id="19" name="cargo test #19" package="testsuite/cargo test #19" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-16T06:10:32.081394059+00:00" time="0" />
+  <testsuite id="20" name="cargo test #20" package="testsuite/cargo test #20" tests="92" errors="0" failures="0" hostname="localhost" timestamp="2020-06-16T06:10:32.081394059+00:00" time="0">
+    <testcase name="Blob (line 39)" classname="srcindingslob.rs - bindings::blob" time="0" />
+    <testcase name="Blob (line 26)" classname="srcindingslob.rs - bindings::blob" time="0" />
+    <testcase name="Blob (line 53)" classname="srcindingslob.rs - bindings::blob" time="0" />
+    <testcase name="BlobTrigger (line 29)" classname="srcindingslob_trigger.rs - bindings::blob_trigger" time="0" />
+    <testcase name="CosmosDbDocument (line 52)" classname="src\bindings\cosmos_db_document.rs - bindings::cosmos_db_document" time="0" />
+    <testcase name="CosmosDbDocument (line 31)" classname="src\bindings\cosmos_db_document.rs - bindings::cosmos_db_document" time="0" />
+    <testcase name="CosmosDbTrigger (line 32)" classname="src\bindings\cosmos_db_trigger.rs - bindings::cosmos_db_trigger" time="0" />
+    <testcase name="CosmosDbDocument (line 74)" classname="src\bindings\cosmos_db_document.rs - bindings::cosmos_db_document" time="0" />
+    <testcase name="EventGridEvent (line 20)" classname="src\bindings\event_grid_event.rs - bindings::event_grid_event" time="0" />
+    <testcase name="EventHubMessage (line 27)" classname="src\bindings\event_hub_message.rs - bindings::event_hub_message" time="0" />
+    <testcase name="EventHubMessage (line 40)" classname="src\bindings\event_hub_message.rs - bindings::event_hub_message" time="0" />
+    <testcase name="EventHubMessage (line 54)" classname="src\bindings\event_hub_message.rs - bindings::event_hub_message" time="0" />
+    <testcase name="EventHubTrigger (line 31)" classname="src\bindings\event_hub_trigger.rs - bindings::event_hub_trigger" time="0" />
+    <testcase name="GenericInput (line 17)" classname="src\bindings\generic_input.rs - bindings::generic_input" time="0" />
+    <testcase name="GenericOutput (line 20)" classname="src\bindings\generic_output.rs - bindings::generic_output" time="0" />
+    <testcase name="GenericTrigger (line 18)" classname="src\bindings\generic_trigger.rs - bindings::generic_trigger" time="0" />
+    <testcase name="query_params (line 99)" classname="src\bindings\http_request.rs - bindings::http_request::HttpRequest" time="0" />
+    <testcase name="HttpRequest (line 22)" classname="src\bindings\http_request.rs - bindings::http_request" time="0" />
+    <testcase name="route_params (line 73)" classname="src\bindings\http_request.rs - bindings::http_request::HttpRequest" time="0" />
+    <testcase name="HttpResponse (line 21)" classname="src\bindings\http_response.rs - bindings::http_response" time="0" />
+    <testcase name="HttpResponse (line 46)" classname="src\bindings\http_response.rs - bindings::http_response" time="0" />
+    <testcase name="HttpResponse (line 33)" classname="src\bindings\http_response.rs - bindings::http_response" time="0" />
+    <testcase name="HttpResponse (line 58)" classname="src\bindings\http_response.rs - bindings::http_response" time="0" />
+    <testcase name="body (line 120)" classname="src\bindings\http_response.rs - bindings::http_response::HttpResponse" time="0" />
+    <testcase name="build (line 90)" classname="src\bindings\http_response.rs - bindings::http_response::HttpResponse" time="0" />
+    <testcase name="headers (line 138)" classname="src\bindings\http_response.rs - bindings::http_response::HttpResponse" time="0" />
+    <testcase name="status (line 105)" classname="src\bindings\http_response.rs - bindings::http_response::HttpResponse" time="0" />
+    <testcase name="QueueMessage (line 27)" classname="src\bindings\queue_message.rs - bindings::queue_message" time="0" />
+    <testcase name="QueueMessage (line 40)" classname="src\bindings\queue_message.rs - bindings::queue_message" time="0" />
+    <testcase name="QueueMessage (line 54)" classname="src\bindings\queue_message.rs - bindings::queue_message" time="0" />
+    <testcase name="QueueTrigger (line 30)" classname="src\bindings\queue_trigger.rs - bindings::queue_trigger" time="0" />
+    <testcase name="SendGridMessage (line 26)" classname="src\bindings\send_grid_message.rs - bindings::send_grid_message" time="0" />
+    <testcase name="build (line 107)" classname="src\bindings\send_grid_message.rs - bindings::send_grid_message::SendGridMessage" time="0" />
+    <testcase name="ServiceBusMessage (line 29)" classname="src\bindings\service_bus_message.rs - bindings::service_bus_message" time="0" />
+    <testcase name="ServiceBusMessage (line 48)" classname="src\bindings\service_bus_message.rs - bindings::service_bus_message" time="0" />
+    <testcase name="ServiceBusTrigger (line 39)" classname="src\bindings\service_bus_trigger.rs - bindings::service_bus_trigger" time="0" />
+    <testcase name="ServiceBusTrigger (line 54)" classname="src\bindings\service_bus_trigger.rs - bindings::service_bus_trigger" time="0" />
+    <testcase name="SignalRConnectionInfo (line 24)" classname="src\bindings\signalr_connection_info.rs - bindings::signalr_connection_info" time="0" />
+    <testcase name="SignalRGroupAction (line 23)" classname="src\bindings\signalr_group_action.rs - bindings::signalr_group_action" time="0" />
+    <testcase name="SignalRMessage (line 22)" classname="src\bindings\signalr_message.rs - bindings::signalr_message" time="0" />
+    <testcase name="Table (line 26)" classname="srcindings	able.rs - bindings::table" time="0" />
+    <testcase name="Table (line 40)" classname="srcindings	able.rs - bindings::table" time="0" />
+    <testcase name="TimerInfo (line 24)" classname="srcindings	imer_info.rs - bindings::timer_info" time="0" />
+    <testcase name="TwilioSmsMessage (line 24)" classname="srcindings	wilio_sms_message.rs - bindings::twilio_sms_message" time="0" />
+    <testcase name="as_bytes (line 73)" classname="src\http\body.rs - http::body::Body" time="0" />
+    <testcase name="as_json (line 93)" classname="src\http\body.rs - http::body::Body" time="0" />
+    <testcase name="as_str (line 53)" classname="src\http\body.rs - http::body::Body" time="0" />
+    <testcase name="default_content_type (line 32)" classname="src\http\body.rs - http::body::Body" time="0" />
+    <testcase name="body (line 65)" classname="src\http\response_builder.rs - http::response_builder::ResponseBuilder" time="0" />
+    <testcase name="header (line 37)" classname="src\http\response_builder.rs - http::response_builder::ResponseBuilder" time="0" />
+    <testcase name="status (line 18)" classname="src\http\response_builder.rs - http::response_builder::ResponseBuilder" time="0" />
+    <testcase name="from_code (line 21)" classname="src\http\status.rs - http::status::Status" time="0" />
+    <testcase name="new (line 18)" classname="src\send_grid\email_address.rs - send_grid::email_address::EmailAddress" time="0" />
+    <testcase name="new_with_name (line 38)" classname="src\send_grid\email_address.rs - send_grid::email_address::EmailAddress" time="0" />
+    <testcase name="attachment (line 580)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="attachments (line 652)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="batch_id (line 895)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="bcc (line 160)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="bcc_with_name (line 180)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="bccs (line 201)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="categories (line 762)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="category (line 743)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="cc (line 91)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="cc_with_name (line 111)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="ccs (line 132)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="content (line 502)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="content_with_type (line 526)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="contents (line 551)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="custom_arg (line 372)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="custom_args (line 395)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="from (line 441)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="from_with_name (line 461)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="global_custom_arg (line 828)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="global_custom_args (line 849)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="global_header (line 783)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="global_headers (line 803)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="global_send_at (line 878)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="global_subject (line 483)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="header (line 249)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="headers (line 272)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="inline_attachment (line 611)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="section (line 698)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="sections (line 718)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="send_at (line 424)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="subject (line 229)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="substitution (line 298)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="substitutions (line 321)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="template_data (line 349)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="template_id (line 678)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="to (line 21)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="to_with_name (line 41)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
+    <testcase name="tos (line 63)" classname="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder" time="0" />
   </testsuite>
-  <testsuite id="3" name="cargo test #3" package="testsuite/cargo test #3" tests="205" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:05.997283800+00:00" time="0">
-    <testcase name="codegen::bindings::blob::tests::it_converts_to_tokens" time="0" />
-    <testcase name="codegen::bindings::blob::tests::it_parses_attribute_arguments" time="0" />
-    <testcase name="codegen::bindings::blob::tests::it_requires_the_name_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::blob::tests::it_requires_the_connection_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::blob::tests::it_requires_the_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::blob::tests::it_requires_the_path_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::blob::tests::it_requires_the_path_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::blob::tests::it_serializes_to_json" time="0" />
-    <testcase name="codegen::bindings::blob_trigger::tests::it_converts_to_tokens" time="0" />
-    <testcase name="codegen::bindings::blob_trigger::tests::it_requires_the_connection_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::blob_trigger::tests::it_parses_attribute_arguments" time="0" />
-    <testcase name="codegen::bindings::blob_trigger::tests::it_requires_the_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::blob_trigger::tests::it_requires_the_name_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::blob_trigger::tests::it_requires_the_path_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::blob_trigger::tests::it_requires_the_path_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::blob_trigger::tests::it_serializes_to_json" time="0" />
-    <testcase name="codegen::bindings::cosmos_db::tests::it_parses_attribute_arguments" time="0" />
-    <testcase name="codegen::bindings::cosmos_db::tests::it_converts_to_tokens" time="0" />
-    <testcase name="codegen::bindings::cosmos_db::tests::it_requires_the_collection_name_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::cosmos_db::tests::it_requires_the_collection_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::cosmos_db::tests::it_requires_the_collection_throughput_attribute_be_an_integer" time="0" />
-    <testcase name="codegen::bindings::cosmos_db::tests::it_requires_the_connection_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::cosmos_db::tests::it_requires_the_connection_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::cosmos_db::tests::it_requires_the_create_collection_attribute_be_a_bool" time="0" />
-    <testcase name="codegen::bindings::cosmos_db::tests::it_requires_the_database_name_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::cosmos_db::tests::it_requires_the_database_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::cosmos_db::tests::it_requires_the_name_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::cosmos_db::tests::it_requires_the_id_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::cosmos_db::tests::it_requires_the_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::cosmos_db::tests::it_requires_the_partition_key_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::cosmos_db::tests::it_requires_the_sql_query_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::cosmos_db::tests::it_serializes_to_json" time="0" />
-    <testcase name="codegen::bindings::cosmos_db_trigger::tests::it_converts_to_tokens" time="0" />
-    <testcase name="codegen::bindings::cosmos_db_trigger::tests::it_requires_the_checkpoint_frequency_attribute_be_an_integer" time="0" />
-    <testcase name="codegen::bindings::cosmos_db_trigger::tests::it_parses_attribute_arguments" time="0" />
-    <testcase name="codegen::bindings::cosmos_db_trigger::tests::it_requires_the_collection_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::cosmos_db_trigger::tests::it_requires_the_collection_name_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::cosmos_db_trigger::tests::it_requires_the_connection_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::cosmos_db_trigger::tests::it_requires_the_connection_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::cosmos_db_trigger::tests::it_requires_the_create_lease_collection_attribute_be_a_boolean" time="0" />
-    <testcase name="codegen::bindings::cosmos_db_trigger::tests::it_requires_the_database_name_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::cosmos_db_trigger::tests::it_requires_the_feed_poll_delay_attribute_be_an_integer" time="0" />
-    <testcase name="codegen::bindings::cosmos_db_trigger::tests::it_requires_the_database_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::cosmos_db_trigger::tests::it_requires_the_lease_collection_prefix_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::cosmos_db_trigger::tests::it_requires_the_lease_acquire_interval_attribute_be_an_integer" time="0" />
-    <testcase name="codegen::bindings::cosmos_db_trigger::tests::it_requires_the_lease_collection_throughput_attribute_be_an_integer" time="0" />
-    <testcase name="codegen::bindings::cosmos_db_trigger::tests::it_requires_the_lease_connection_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::cosmos_db_trigger::tests::it_requires_the_lease_renew_interval_attribute_be_an_integer" time="0" />
-    <testcase name="codegen::bindings::cosmos_db_trigger::tests::it_requires_the_lease_expiration_interval_attribute_be_an_integer" time="0" />
-    <testcase name="codegen::bindings::cosmos_db_trigger::tests::it_requires_the_name_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::cosmos_db_trigger::tests::it_requires_the_max_items_per_invocation_attribute_be_an_integer" time="0" />
-    <testcase name="codegen::bindings::cosmos_db_trigger::tests::it_requires_the_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::cosmos_db_trigger::tests::it_serializes_to_json" time="0" />
-    <testcase name="codegen::bindings::cosmos_db_trigger::tests::it_requires_the_start_from_beginning_attribute_be_a_boolean" time="0" />
-    <testcase name="codegen::bindings::event_grid_trigger::tests::it_converts_to_tokens" time="0" />
-    <testcase name="codegen::bindings::event_grid_trigger::tests::it_parses_attribute_arguments" time="0" />
-    <testcase name="codegen::bindings::event_grid_trigger::tests::it_requires_the_name_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::event_grid_trigger::tests::it_requires_the_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::event_grid_trigger::tests::it_serializes_to_json" time="0" />
-    <testcase name="codegen::bindings::event_hub::tests::it_parses_attribute_arguments" time="0" />
-    <testcase name="codegen::bindings::event_hub::tests::it_converts_to_tokens" time="0" />
-    <testcase name="codegen::bindings::event_hub::tests::it_requires_the_connection_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::event_hub::tests::it_requires_the_connection_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::event_hub::tests::it_requires_the_name_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::event_hub::tests::it_requires_the_event_hub_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::event_hub::tests::it_requires_the_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::event_hub::tests::it_serializes_to_json" time="0" />
-    <testcase name="codegen::bindings::event_hub_trigger::tests::it_parses_attribute_arguments" time="0" />
-    <testcase name="codegen::bindings::event_hub_trigger::tests::it_converts_to_tokens" time="0" />
-    <testcase name="codegen::bindings::event_hub_trigger::tests::it_requires_the_connection_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::event_hub_trigger::tests::it_requires_the_consumer_group_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::event_hub_trigger::tests::it_requires_the_connection_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::event_hub_trigger::tests::it_requires_the_event_hub_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::event_hub_trigger::tests::it_requires_the_name_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::event_hub_trigger::tests::it_requires_the_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::event_hub_trigger::tests::it_serializes_to_json" time="0" />
-    <testcase name="codegen::bindings::generic::tests::it_converts_to_tokens" time="0" />
-    <testcase name="codegen::bindings::generic::tests::it_parses_attribute_arguments" time="0" />
-    <testcase name="codegen::bindings::generic::tests::it_requires_the_name_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::generic::tests::it_requires_the_type_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::generic::tests::it_requires_the_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::generic::tests::it_requires_the_type_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::http::tests::it_converts_to_tokens" time="0" />
-    <testcase name="codegen::bindings::generic::tests::it_serializes_to_json" time="0" />
-    <testcase name="codegen::bindings::http::tests::it_requires_the_name_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::http::tests::it_parses_attribute_arguments" time="0" />
-    <testcase name="codegen::bindings::http::tests::it_requires_the_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::http::tests::it_serializes_to_json" time="0" />
-    <testcase name="codegen::bindings::http_trigger::tests::it_accepts_valid_methods" time="0" />
-    <testcase name="codegen::bindings::http_trigger::tests::it_accepts_valid_auth_levels" time="0" />
-    <testcase name="codegen::bindings::http_trigger::tests::it_converts_to_tokens" time="0" />
-    <testcase name="codegen::bindings::http_trigger::tests::it_rejects_invalid_auth_levels" time="0" />
-    <testcase name="codegen::bindings::http_trigger::tests::it_parses_attribute_arguments" time="0" />
-    <testcase name="codegen::bindings::http_trigger::tests::it_requires_the_auth_level_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::http_trigger::tests::it_rejects_invalid_methods" time="0" />
-    <testcase name="codegen::bindings::http_trigger::tests::it_requires_the_methods_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::http_trigger::tests::it_requires_the_name_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::http_trigger::tests::it_requires_the_route_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::http_trigger::tests::it_requires_the_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::queue::tests::it_converts_to_tokens" time="0" />
-    <testcase name="codegen::bindings::http_trigger::tests::it_serializes_to_json" time="0" />
-    <testcase name="codegen::bindings::queue::tests::it_parses_attribute_arguments" time="0" />
-    <testcase name="codegen::bindings::queue::tests::it_requires_the_connection_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::queue::tests::it_requires_the_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::queue::tests::it_requires_the_name_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::queue::tests::it_requires_the_queue_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::queue::tests::it_requires_the_queue_name_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::queue_trigger::tests::it_converts_to_tokens" time="0" />
-    <testcase name="codegen::bindings::queue::tests::it_serializes_to_json" time="0" />
-    <testcase name="codegen::bindings::queue_trigger::tests::it_requires_the_connection_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::queue_trigger::tests::it_parses_attribute_arguments" time="0" />
-    <testcase name="codegen::bindings::queue_trigger::tests::it_requires_the_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::queue_trigger::tests::it_requires_the_name_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::queue_trigger::tests::it_requires_the_queue_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::queue_trigger::tests::it_requires_the_queue_name_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::queue_trigger::tests::it_serializes_to_json" time="0" />
-    <testcase name="codegen::bindings::send_grid::tests::it_converts_to_tokens" time="0" />
-    <testcase name="codegen::bindings::send_grid::tests::it_requires_the_api_key_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::send_grid::tests::it_parses_attribute_arguments" time="0" />
-    <testcase name="codegen::bindings::send_grid::tests::it_requires_the_from_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::send_grid::tests::it_requires_the_name_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::send_grid::tests::it_requires_the_subject_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::send_grid::tests::it_requires_the_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::send_grid::tests::it_requires_the_text_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::send_grid::tests::it_requires_the_to_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::send_grid::tests::it_serializes_to_json" time="0" />
-    <testcase name="codegen::bindings::service_bus::tests::it_converts_to_tokens" time="0" />
-    <testcase name="codegen::bindings::service_bus::tests::it_requires_queue_name_or_topic_subscription" time="0" />
-    <testcase name="codegen::bindings::service_bus::tests::it_parses_attribute_arguments" time="0" />
-    <testcase name="codegen::bindings::service_bus::tests::it_requires_the_connection_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::service_bus::tests::it_requires_the_name_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::service_bus::tests::it_requires_the_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::service_bus::tests::it_requires_the_queue_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::service_bus::tests::it_requires_the_topic_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::service_bus::tests::it_requires_the_subscription_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::service_bus::tests::it_serializes_to_json" time="0" />
-    <testcase name="codegen::bindings::service_bus_trigger::tests::it_converts_to_tokens" time="0" />
-    <testcase name="codegen::bindings::service_bus_trigger::tests::it_parses_attribute_arguments" time="0" />
-    <testcase name="codegen::bindings::service_bus_trigger::tests::it_requires_queue_name_or_topic_subscription" time="0" />
-    <testcase name="codegen::bindings::service_bus_trigger::tests::it_requires_the_name_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::service_bus_trigger::tests::it_requires_the_connection_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::service_bus_trigger::tests::it_requires_the_queue_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::service_bus_trigger::tests::it_requires_the_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::service_bus_trigger::tests::it_requires_the_topic_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::service_bus_trigger::tests::it_requires_the_subscription_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::service_bus_trigger::tests::it_serializes_to_json" time="0" />
-    <testcase name="codegen::bindings::signalr::tests::it_converts_to_tokens" time="0" />
-    <testcase name="codegen::bindings::signalr::tests::it_parses_attribute_arguments" time="0" />
-    <testcase name="codegen::bindings::signalr::tests::it_requires_the_connection_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::signalr::tests::it_requires_the_name_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::signalr::tests::it_requires_the_hub_name_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::signalr::tests::it_requires_the_queue_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::signalr::tests::it_requires_the_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::signalr::tests::it_serializes_to_json" time="0" />
-    <testcase name="codegen::bindings::signalr_connection_info::tests::it_converts_to_tokens" time="0" />
-    <testcase name="codegen::bindings::signalr_connection_info::tests::it_parses_attribute_arguments" time="0" />
-    <testcase name="codegen::bindings::signalr_connection_info::tests::it_requires_the_connection_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::signalr_connection_info::tests::it_requires_the_hub_name_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::signalr_connection_info::tests::it_requires_the_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::signalr_connection_info::tests::it_requires_the_name_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::signalr_connection_info::tests::it_requires_the_queue_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::signalr_connection_info::tests::it_serializes_to_json" time="0" />
-    <testcase name="codegen::bindings::signalr_connection_info::tests::it_requires_the_user_id_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::table::tests::it_parses_attribute_arguments" time="0" />
-    <testcase name="codegen::bindings::table::tests::it_converts_to_tokens" time="0" />
-    <testcase name="codegen::bindings::table::tests::it_requires_the_connection_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::table::tests::it_requires_the_filter_be_a_string" time="0" />
-    <testcase name="codegen::bindings::table::tests::it_requires_the_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::table::tests::it_requires_the_name_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::table::tests::it_requires_the_row_key_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::table::tests::it_requires_the_partition_key_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::table::tests::it_requires_the_table_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::table::tests::it_requires_the_table_name_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::table::tests::it_serializes_to_json" time="0" />
-    <testcase name="codegen::bindings::table::tests::it_requires_the_take_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::timer_trigger::tests::it_parses_attribute_arguments" time="0" />
-    <testcase name="codegen::bindings::timer_trigger::tests::it_converts_to_tokens" time="0" />
-    <testcase name="codegen::bindings::timer_trigger::tests::it_requires_the_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::timer_trigger::tests::it_requires_the_name_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::timer_trigger::tests::it_requires_the_run_on_startup_attribute_be_a_bool" time="0" />
-    <testcase name="codegen::bindings::timer_trigger::tests::it_requires_the_schedule_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::timer_trigger::tests::it_requires_the_schedule_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::timer_trigger::tests::it_requires_the_use_monitor_attribute_be_a_bool" time="0" />
-    <testcase name="codegen::bindings::timer_trigger::tests::it_serializes_to_json" time="0" />
-    <testcase name="codegen::bindings::twilio_sms::tests::it_converts_to_tokens" time="0" />
-    <testcase name="codegen::bindings::twilio_sms::tests::it_requires_the_account_sid_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::twilio_sms::tests::it_parses_attribute_arguments" time="0" />
-    <testcase name="codegen::bindings::twilio_sms::tests::it_requires_the_body_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::twilio_sms::tests::it_requires_the_auth_token_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::twilio_sms::tests::it_requires_the_from_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::twilio_sms::tests::it_requires_the_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::bindings::twilio_sms::tests::it_requires_the_name_attribute_argument" time="0" />
-    <testcase name="codegen::bindings::twilio_sms::tests::it_serializes_to_json" time="0" />
-    <testcase name="codegen::function::tests::it_parses_attribute_arguments" time="0" />
-    <testcase name="codegen::function::tests::it_converts_to_tokens" time="0" />
-    <testcase name="codegen::function::tests::it_requires_an_identifier_for_name" time="0" />
-    <testcase name="codegen::function::tests::it_requires_the_disabled_attribute_be_a_boolean" time="0" />
-    <testcase name="codegen::function::tests::it_serializes_to_json" time="0" />
-    <testcase name="codegen::function::tests::it_requires_the_name_attribute_be_a_string" time="0" />
-    <testcase name="codegen::value::tests::it_converts_boolean_to_tokens" time="0" />
-    <testcase name="codegen::value::tests::it_converts_integer_to_tokens" time="0" />
-    <testcase name="codegen::value::tests::it_serializes_boolean_to_json" time="0" />
-    <testcase name="codegen::value::tests::it_converts_string_to_tokens" time="0" />
-    <testcase name="codegen::value::tests::it_serializes_string_to_json" time="0" />
-    <testcase name="codegen::value::tests::it_serializes_integer_to_json" time="0" />
-    <system-out />
-    <system-err />
-  </testsuite>
-  <testsuite id="4" name="cargo test #4" package="testsuite/cargo test #4" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:05.997283800+00:00" time="0">
-    <system-out />
-    <system-err />
-  </testsuite>
-  <testsuite id="5" name="cargo test #5" package="testsuite/cargo test #5" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:05.997283800+00:00" time="0">
-    <system-out />
-    <system-err />
-  </testsuite>
-  <testsuite id="6" name="cargo test #6" package="testsuite/cargo test #6" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:05.997283800+00:00" time="0">
-    <system-out />
-    <system-err />
-  </testsuite>
-  <testsuite id="7" name="cargo test #7" package="testsuite/cargo test #7" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:05.997283800+00:00" time="0">
-    <system-out />
-    <system-err />
-  </testsuite>
-  <testsuite id="8" name="cargo test #8" package="testsuite/cargo test #8" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:05.997283800+00:00" time="0">
-    <system-out />
-    <system-err />
-  </testsuite>
-  <testsuite id="9" name="cargo test #9" package="testsuite/cargo test #9" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:05.997283800+00:00" time="0">
-    <system-out />
-    <system-err />
-  </testsuite>
-  <testsuite id="10" name="cargo test #10" package="testsuite/cargo test #10" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:05.997283800+00:00" time="0">
-    <system-out />
-    <system-err />
-  </testsuite>
-  <testsuite id="11" name="cargo test #11" package="testsuite/cargo test #11" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:05.997283800+00:00" time="0">
-    <system-out />
-    <system-err />
-  </testsuite>
-  <testsuite id="12" name="cargo test #12" package="testsuite/cargo test #12" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:05.997283800+00:00" time="0">
-    <system-out />
-    <system-err />
-  </testsuite>
-  <testsuite id="13" name="cargo test #13" package="testsuite/cargo test #13" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:05.997283800+00:00" time="0">
-    <system-out />
-    <system-err />
-  </testsuite>
-  <testsuite id="14" name="cargo test #14" package="testsuite/cargo test #14" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:05.997283800+00:00" time="0">
-    <system-out />
-    <system-err />
-  </testsuite>
-  <testsuite id="15" name="cargo test #15" package="testsuite/cargo test #15" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:05.997283800+00:00" time="0">
-    <system-out />
-    <system-err />
-  </testsuite>
-  <testsuite id="16" name="cargo test #16" package="testsuite/cargo test #16" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:05.997283800+00:00" time="0">
-    <system-out />
-    <system-err />
-  </testsuite>
-  <testsuite id="17" name="cargo test #17" package="testsuite/cargo test #17" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:05.997283800+00:00" time="0">
-    <system-out />
-    <system-err />
-  </testsuite>
-  <testsuite id="18" name="cargo test #18" package="testsuite/cargo test #18" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:05.997283800+00:00" time="0">
-    <system-out />
-    <system-err />
-  </testsuite>
-  <testsuite id="19" name="cargo test #19" package="testsuite/cargo test #19" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:05.997283800+00:00" time="0">
-    <system-out />
-    <system-err />
-  </testsuite>
-  <testsuite id="20" name="cargo test #20" package="testsuite/cargo test #20" tests="92" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:05.997283800+00:00" time="0">
-    <testcase name="srcindingslob.rs - bindings::blob::Blob (line 39)" time="0" />
-    <testcase name="srcindingslob.rs - bindings::blob::Blob (line 26)" time="0" />
-    <testcase name="srcindingslob.rs - bindings::blob::Blob (line 53)" time="0" />
-    <testcase name="srcindingslob_trigger.rs - bindings::blob_trigger::BlobTrigger (line 29)" time="0" />
-    <testcase name="src\bindings\cosmos_db_document.rs - bindings::cosmos_db_document::CosmosDbDocument (line 52)" time="0" />
-    <testcase name="src\bindings\cosmos_db_document.rs - bindings::cosmos_db_document::CosmosDbDocument (line 31)" time="0" />
-    <testcase name="src\bindings\cosmos_db_trigger.rs - bindings::cosmos_db_trigger::CosmosDbTrigger (line 32)" time="0" />
-    <testcase name="src\bindings\cosmos_db_document.rs - bindings::cosmos_db_document::CosmosDbDocument (line 74)" time="0" />
-    <testcase name="src\bindings\event_grid_event.rs - bindings::event_grid_event::EventGridEvent (line 20)" time="0" />
-    <testcase name="src\bindings\event_hub_message.rs - bindings::event_hub_message::EventHubMessage (line 27)" time="0" />
-    <testcase name="src\bindings\event_hub_message.rs - bindings::event_hub_message::EventHubMessage (line 40)" time="0" />
-    <testcase name="src\bindings\event_hub_message.rs - bindings::event_hub_message::EventHubMessage (line 54)" time="0" />
-    <testcase name="src\bindings\event_hub_trigger.rs - bindings::event_hub_trigger::EventHubTrigger (line 31)" time="0" />
-    <testcase name="src\bindings\generic_input.rs - bindings::generic_input::GenericInput (line 17)" time="0" />
-    <testcase name="src\bindings\generic_output.rs - bindings::generic_output::GenericOutput (line 20)" time="0" />
-    <testcase name="src\bindings\generic_trigger.rs - bindings::generic_trigger::GenericTrigger (line 18)" time="0" />
-    <testcase name="src\bindings\http_request.rs - bindings::http_request::HttpRequest::query_params (line 99)" time="0" />
-    <testcase name="src\bindings\http_request.rs - bindings::http_request::HttpRequest (line 22)" time="0" />
-    <testcase name="src\bindings\http_request.rs - bindings::http_request::HttpRequest::route_params (line 73)" time="0" />
-    <testcase name="src\bindings\http_response.rs - bindings::http_response::HttpResponse (line 21)" time="0" />
-    <testcase name="src\bindings\http_response.rs - bindings::http_response::HttpResponse (line 46)" time="0" />
-    <testcase name="src\bindings\http_response.rs - bindings::http_response::HttpResponse (line 33)" time="0" />
-    <testcase name="src\bindings\http_response.rs - bindings::http_response::HttpResponse (line 58)" time="0" />
-    <testcase name="src\bindings\http_response.rs - bindings::http_response::HttpResponse::body (line 120)" time="0" />
-    <testcase name="src\bindings\http_response.rs - bindings::http_response::HttpResponse::build (line 90)" time="0" />
-    <testcase name="src\bindings\http_response.rs - bindings::http_response::HttpResponse::headers (line 138)" time="0" />
-    <testcase name="src\bindings\http_response.rs - bindings::http_response::HttpResponse::status (line 105)" time="0" />
-    <testcase name="src\bindings\queue_message.rs - bindings::queue_message::QueueMessage (line 27)" time="0" />
-    <testcase name="src\bindings\queue_message.rs - bindings::queue_message::QueueMessage (line 40)" time="0" />
-    <testcase name="src\bindings\queue_message.rs - bindings::queue_message::QueueMessage (line 54)" time="0" />
-    <testcase name="src\bindings\queue_trigger.rs - bindings::queue_trigger::QueueTrigger (line 30)" time="0" />
-    <testcase name="src\bindings\send_grid_message.rs - bindings::send_grid_message::SendGridMessage (line 26)" time="0" />
-    <testcase name="src\bindings\send_grid_message.rs - bindings::send_grid_message::SendGridMessage::build (line 107)" time="0" />
-    <testcase name="src\bindings\service_bus_message.rs - bindings::service_bus_message::ServiceBusMessage (line 29)" time="0" />
-    <testcase name="src\bindings\service_bus_message.rs - bindings::service_bus_message::ServiceBusMessage (line 48)" time="0" />
-    <testcase name="src\bindings\service_bus_trigger.rs - bindings::service_bus_trigger::ServiceBusTrigger (line 39)" time="0" />
-    <testcase name="src\bindings\service_bus_trigger.rs - bindings::service_bus_trigger::ServiceBusTrigger (line 54)" time="0" />
-    <testcase name="src\bindings\signalr_connection_info.rs - bindings::signalr_connection_info::SignalRConnectionInfo (line 24)" time="0" />
-    <testcase name="src\bindings\signalr_group_action.rs - bindings::signalr_group_action::SignalRGroupAction (line 23)" time="0" />
-    <testcase name="src\bindings\signalr_message.rs - bindings::signalr_message::SignalRMessage (line 22)" time="0" />
-    <testcase name="srcindings	able.rs - bindings::table::Table (line 26)" time="0" />
-    <testcase name="srcindings	able.rs - bindings::table::Table (line 40)" time="0" />
-    <testcase name="srcindings	imer_info.rs - bindings::timer_info::TimerInfo (line 24)" time="0" />
-    <testcase name="srcindings	wilio_sms_message.rs - bindings::twilio_sms_message::TwilioSmsMessage (line 24)" time="0" />
-    <testcase name="src\http\body.rs - http::body::Body::as_bytes (line 73)" time="0" />
-    <testcase name="src\http\body.rs - http::body::Body::as_json (line 93)" time="0" />
-    <testcase name="src\http\body.rs - http::body::Body::as_str (line 53)" time="0" />
-    <testcase name="src\http\body.rs - http::body::Body::default_content_type (line 32)" time="0" />
-    <testcase name="src\http\response_builder.rs - http::response_builder::ResponseBuilder::body (line 65)" time="0" />
-    <testcase name="src\http\response_builder.rs - http::response_builder::ResponseBuilder::header (line 37)" time="0" />
-    <testcase name="src\http\response_builder.rs - http::response_builder::ResponseBuilder::status (line 18)" time="0" />
-    <testcase name="src\http\status.rs - http::status::Status::from_code (line 21)" time="0" />
-    <testcase name="src\send_grid\email_address.rs - send_grid::email_address::EmailAddress::new (line 18)" time="0" />
-    <testcase name="src\send_grid\email_address.rs - send_grid::email_address::EmailAddress::new_with_name (line 38)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::attachment (line 580)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::attachments (line 652)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::batch_id (line 895)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::bcc (line 160)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::bcc_with_name (line 180)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::bccs (line 201)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::categories (line 762)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::category (line 743)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::cc (line 91)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::cc_with_name (line 111)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::ccs (line 132)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::content (line 502)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::content_with_type (line 526)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::contents (line 551)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::custom_arg (line 372)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::custom_args (line 395)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::from (line 441)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::from_with_name (line 461)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::global_custom_arg (line 828)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::global_custom_args (line 849)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::global_header (line 783)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::global_headers (line 803)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::global_send_at (line 878)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::global_subject (line 483)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::header (line 249)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::headers (line 272)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::inline_attachment (line 611)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::section (line 698)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::sections (line 718)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::send_at (line 424)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::subject (line 229)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::substitution (line 298)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::substitutions (line 321)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::template_data (line 349)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::template_id (line 678)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::to (line 21)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::to_with_name (line 41)" time="0" />
-    <testcase name="src\send_grid\message_builder.rs - send_grid::message_builder::MessageBuilder::tos (line 63)" time="0" />
-    <system-out />
-    <system-err />
-  </testsuite>
-  <testsuite id="21" name="cargo test #21" package="testsuite/cargo test #21" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:05.997283800+00:00" time="0">
-    <system-out />
-    <system-err />
-  </testsuite>
+  <testsuite id="21" name="cargo test #21" package="testsuite/cargo test #21" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-16T06:10:32.081394059+00:00" time="0" />
 </testsuites>

--- a/src/expected_outputs/cargo_failure.json.out
+++ b/src/expected_outputs/cargo_failure.json.out
@@ -1,1543 +1,1539 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-  <testsuite id="0" name="cargo test #0" package="testsuite/cargo test #0" tests="25" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:06.193288200+00:00" time="0">
-    <testcase name="core::package_id_spec::tests::bad_parsing" time="0" />
-    <testcase name="core::package_id_spec::tests::good_parsing" time="0" />
-    <testcase name="core::package_id::tests::invalid_version_handled_nicely" time="0" />
-    <testcase name="core::package_id::tests::display" time="0" />
-    <testcase name="core::package_id_spec::tests::matching" time="0" />
-    <testcase name="core::package_id::tests::debug" time="0" />
-    <testcase name="sources::git::source::test::test_canonicalize_cannot_be_a_base_urls" time="0" />
-    <testcase name="core::source::source_id::tests::github_sources_equal" time="0" />
-    <testcase name="sources::git::source::test::test_canonicalize_idents_different_protocols" time="0" />
-    <testcase name="sources::git::source::test::test_canonicalize_idents_by_lowercasing_github_urls" time="0" />
-    <testcase name="sources::git::source::test::test_canonicalize_idents_by_stripping_dot_git" time="0" />
-    <testcase name="sources::git::source::test::test_canonicalize_idents_by_stripping_trailing_url_slash" time="0" />
-    <testcase name="sources::git::source::test::test_url_to_path_ident_with_path" time="0" />
-    <testcase name="sources::git::source::test::test_url_to_path_ident_without_path" time="0" />
-    <testcase name="sources::registry::index::no_hyphen" time="0" />
-    <testcase name="sources::registry::index::two_hyphen" time="0" />
-    <testcase name="sources::registry::index::overflow_hyphen" time="0" />
-    <testcase name="util::dependency_queue::test::deep_first" time="0" />
-    <testcase name="sources::registry::escaped_cher_in_json" time="0" />
-    <testcase name="util::progress::test_progress_status" time="0" />
-    <testcase name="util::progress::test_progress_status_percentage" time="0" />
-    <testcase name="util::progress::test_progress_status_too_short" time="0" />
-    <testcase name="util::network::with_retry_repeats_the_call_then_works" time="0" />
-    <testcase name="util::network::with_retry_finds_nested_spurious_errors" time="0" />
-    <testcase name="util::lev_distance::test_lev_distance" time="0" />
-    <system-out />
-    <system-err />
+  <testsuite id="0" name="cargo test #0" package="testsuite/cargo test #0" tests="25" errors="0" failures="0" hostname="localhost" timestamp="2020-06-16T06:16:58.513211709+00:00" time="0">
+    <testcase name="bad_parsing" classname="core::package_id_spec::tests" time="0" />
+    <testcase name="good_parsing" classname="core::package_id_spec::tests" time="0" />
+    <testcase name="invalid_version_handled_nicely" classname="core::package_id::tests" time="0" />
+    <testcase name="display" classname="core::package_id::tests" time="0" />
+    <testcase name="matching" classname="core::package_id_spec::tests" time="0" />
+    <testcase name="debug" classname="core::package_id::tests" time="0" />
+    <testcase name="test_canonicalize_cannot_be_a_base_urls" classname="sources::git::source::test" time="0" />
+    <testcase name="github_sources_equal" classname="core::source::source_id::tests" time="0" />
+    <testcase name="test_canonicalize_idents_different_protocols" classname="sources::git::source::test" time="0" />
+    <testcase name="test_canonicalize_idents_by_lowercasing_github_urls" classname="sources::git::source::test" time="0" />
+    <testcase name="test_canonicalize_idents_by_stripping_dot_git" classname="sources::git::source::test" time="0" />
+    <testcase name="test_canonicalize_idents_by_stripping_trailing_url_slash" classname="sources::git::source::test" time="0" />
+    <testcase name="test_url_to_path_ident_with_path" classname="sources::git::source::test" time="0" />
+    <testcase name="test_url_to_path_ident_without_path" classname="sources::git::source::test" time="0" />
+    <testcase name="no_hyphen" classname="sources::registry::index" time="0" />
+    <testcase name="two_hyphen" classname="sources::registry::index" time="0" />
+    <testcase name="overflow_hyphen" classname="sources::registry::index" time="0" />
+    <testcase name="deep_first" classname="util::dependency_queue::test" time="0" />
+    <testcase name="escaped_cher_in_json" classname="sources::registry" time="0" />
+    <testcase name="test_progress_status" classname="util::progress" time="0" />
+    <testcase name="test_progress_status_percentage" classname="util::progress" time="0" />
+    <testcase name="test_progress_status_too_short" classname="util::progress" time="0" />
+    <testcase name="with_retry_repeats_the_call_then_works" classname="util::network" time="0" />
+    <testcase name="with_retry_finds_nested_spurious_errors" classname="util::network" time="0" />
+    <testcase name="test_lev_distance" classname="util::lev_distance" time="0" />
   </testsuite>
-  <testsuite id="1" name="cargo test #1" package="testsuite/cargo test #1" tests="1503" errors="0" failures="2" hostname="localhost" timestamp="2020-06-15T20:58:06.193288200+00:00" time="0">
-    <testcase name="alt_registry::bad_registry_name" time="0" />
-    <testcase name="aaa_trigger_cross_compile_disabled_check" time="0">
+  <testsuite id="1" name="cargo test #1" package="testsuite/cargo test #1" tests="1503" errors="0" failures="2" hostname="localhost" timestamp="2020-06-16T06:16:58.513211709+00:00" time="0">
+    <testcase name="bad_registry_name" classname="alt_registry" time="0" />
+    <testcase name="aaa_trigger_cross_compile_disabled_check" classname="" time="0">
       <failure type="cargo test" message="thread &apos;aaa_trigger_cross_compile_disabled_check&apos; panicked at &apos;Cannot cross compile to i686-pc-windows-msvc.&#xA;&#xA;This failure can be safely ignored. If you would prefer to not see this&#xA;failure, you can set the environment variable CFG_DISABLE_CROSS_TESTS to &quot;1&quot;.&#xA;&#xA;Alternatively, you can install the necessary libraries for cross-compilation with&#xA;&#xA;    rustup target add i686-pc-windows-msvc&#xA;&apos;, tests\testsuite\support\cross_compile.rs:92:5&#xA;note: Run with `RUST_BACKTRACE=1` for a backtrace.&#xA;" />
     </testcase>
-    <testcase name="alt_registry::alt_reg_metadata" time="0" />
-    <testcase name="alt_registry::cannot_publish_to_crates_io_with_registry_dependency" time="0" />
-    <testcase name="alt_registry::alt_registry_and_crates_io_deps" time="0" />
-    <testcase name="alt_registry::block_publish_due_to_no_token" time="0" />
-    <testcase name="alt_registry::depend_on_alt_registry_depends_on_crates_io" time="0" />
-    <testcase name="alt_registry::depend_on_alt_registry" time="0" />
-    <testcase name="alt_registry::is_feature_gated" time="0" />
-    <testcase name="alt_registry::depend_on_alt_registry_depends_on_same_registry" time="0" />
-    <testcase name="alt_registry::depend_on_alt_registry_depends_on_same_registry_no_index" time="0" />
-    <testcase name="alt_registry::passwords_in_url_forbidden" time="0" />
-    <testcase name="alt_registry::patch_alt_reg" time="0" />
-    <testcase name="alt_registry::no_api" time="0" />
-    <testcase name="alt_registry::publish_to_alt_registry" time="0" />
-    <testcase name="alt_registry::registry_incompatible_with_git" time="0" />
-    <testcase name="alt_registry::publish_with_crates_io_dep" time="0" />
-    <testcase name="alt_registry::registry_and_path_dep_works" time="0" />
-    <testcase name="alt_registry::publish_with_registry_dependency" time="0" />
-    <testcase name="bad_config::bad1" time="0" />
-    <testcase name="bad_config::bad2" time="0" />
-    <testcase name="bad_config::bad4" time="0" />
-    <testcase name="bad_config::bad3" time="0" />
-    <testcase name="bad_config::bad6" time="0" />
-    <testcase name="bad_config::bad_cargo_config_jobs" time="0" />
-    <testcase name="bad_config::bad_cargo_lock" time="0" />
-    <testcase name="bad_config::bad_debuginfo" time="0" />
-    <testcase name="bad_config::bad_dependency" time="0" />
-    <testcase name="alt_registry::unknown_registry" time="0" />
-    <testcase name="bad_config::bad_git_dependency" time="0" />
-    <testcase name="bad_config::bad_crate_type" time="0" />
-    <testcase name="bad_config::bad_opt_level" time="0" />
-    <testcase name="bad_config::bad_source_config1" time="0" />
-    <testcase name="bad_config::bad_source_config2" time="0" />
-    <testcase name="bad_config::bad_source_config3" time="0" />
-    <testcase name="bad_config::bad_source_config4" time="0" />
-    <testcase name="bad_config::bad_dependency_in_lockfile" time="0" />
-    <testcase name="bad_config::bad_source_config5" time="0" />
-    <testcase name="bad_config::bad_source_config6" time="0" />
-    <testcase name="bad_config::bad_source_in_cargo_lock" time="0" />
-    <testcase name="bad_config::bad_source_config7" time="0" />
-    <testcase name="bad_config::duplicate_bench_names" time="0" />
-    <testcase name="bad_config::duplicate_binary_names" time="0" />
-    <testcase name="bad_config::duplicate_deps" time="0" />
-    <testcase name="bad_config::duplicate_deps_diff_sources" time="0" />
-    <testcase name="bad_config::duplicate_example_names" time="0" />
-    <testcase name="bad_config::default_cargo_config_jobs" time="0" />
-    <testcase name="bad_config::ambiguous_git_reference" time="0" />
-    <testcase name="bad_config::duplicate_packages_in_cargo_lock" time="0" />
-    <testcase name="bad_config::ignored_git_revision" time="0" />
-    <testcase name="bad_config::invalid_global_config" time="0" />
-    <testcase name="bad_config::good_cargo_config_jobs" time="0" />
-    <testcase name="bad_config::malformed_override" time="0" />
-    <testcase name="bad_config::invalid_toml_historically_allowed_is_warned" time="0" />
-    <testcase name="bad_config::empty_dependencies" time="0" />
-    <testcase name="bad_manifest_path::bench_dir_containing_cargo_toml" time="0" />
-    <testcase name="bad_manifest_path::bench_dir_plus_file" time="0" />
-    <testcase name="bad_manifest_path::bench_dir_plus_path" time="0" />
-    <testcase name="bad_manifest_path::bench_dir_to_nonexistent_cargo_toml" time="0" />
-    <testcase name="bad_manifest_path::build_dir_containing_cargo_toml" time="0" />
-    <testcase name="bad_config::unused_keys_in_virtual_manifest" time="0" />
-    <testcase name="bad_manifest_path::build_dir_plus_file" time="0" />
-    <testcase name="bad_manifest_path::build_dir_plus_path" time="0" />
-    <testcase name="bad_manifest_path::build_dir_to_nonexistent_cargo_toml" time="0" />
-    <testcase name="bad_manifest_path::clean_dir_containing_cargo_toml" time="0" />
-    <testcase name="bad_manifest_path::clean_dir_plus_file" time="0" />
-    <testcase name="bad_manifest_path::clean_dir_plus_path" time="0" />
-    <testcase name="bad_manifest_path::clean_dir_to_nonexistent_cargo_toml" time="0" />
-    <testcase name="bad_manifest_path::doc_dir_containing_cargo_toml" time="0" />
-    <testcase name="bad_manifest_path::doc_dir_plus_file" time="0" />
-    <testcase name="bad_manifest_path::doc_dir_plus_path" time="0" />
-    <testcase name="bad_manifest_path::doc_dir_to_nonexistent_cargo_toml" time="0" />
-    <testcase name="bad_manifest_path::fetch_dir_containing_cargo_toml" time="0" />
-    <testcase name="bad_manifest_path::fetch_dir_plus_file" time="0" />
-    <testcase name="bad_config::both_git_and_path_specified" time="0" />
-    <testcase name="bad_manifest_path::fetch_dir_plus_path" time="0" />
-    <testcase name="bad_manifest_path::fetch_dir_to_nonexistent_cargo_toml" time="0" />
-    <testcase name="bad_manifest_path::generate_lockfile_dir_plus_file" time="0" />
-    <testcase name="bad_manifest_path::generate_lockfile_dir_containing_cargo_toml" time="0" />
-    <testcase name="bad_manifest_path::generate_lockfile_dir_plus_path" time="0" />
-    <testcase name="bad_manifest_path::generate_lockfile_dir_to_nonexistent_cargo_toml" time="0" />
-    <testcase name="bad_manifest_path::package_dir_containing_cargo_toml" time="0" />
-    <testcase name="bad_manifest_path::package_dir_plus_file" time="0" />
-    <testcase name="bad_manifest_path::package_dir_plus_path" time="0" />
-    <testcase name="bad_manifest_path::package_dir_to_nonexistent_cargo_toml" time="0" />
-    <testcase name="bad_manifest_path::pkgid_dir_containing_cargo_toml" time="0" />
-    <testcase name="bad_manifest_path::pkgid_dir_plus_file" time="0" />
-    <testcase name="bad_manifest_path::pkgid_dir_plus_path" time="0" />
-    <testcase name="bad_manifest_path::pkgid_dir_to_nonexistent_cargo_toml" time="0" />
-    <testcase name="bad_manifest_path::publish_dir_containing_cargo_toml" time="0" />
-    <testcase name="bad_manifest_path::publish_dir_plus_file" time="0" />
-    <testcase name="bad_manifest_path::publish_dir_plus_path" time="0" />
-    <testcase name="bad_manifest_path::publish_dir_to_nonexistent_cargo_toml" time="0" />
-    <testcase name="bad_manifest_path::read_manifest_dir_containing_cargo_toml" time="0" />
-    <testcase name="bad_manifest_path::read_manifest_dir_plus_file" time="0" />
-    <testcase name="bad_manifest_path::read_manifest_dir_plus_path" time="0" />
-    <testcase name="bad_manifest_path::read_manifest_dir_to_nonexistent_cargo_toml" time="0" />
-    <testcase name="bad_manifest_path::run_dir_containing_cargo_toml" time="0" />
-    <testcase name="bad_manifest_path::run_dir_plus_file" time="0" />
-    <testcase name="bad_manifest_path::run_dir_plus_path" time="0" />
-    <testcase name="bad_manifest_path::run_dir_to_nonexistent_cargo_toml" time="0" />
-    <testcase name="bad_config::unused_keys" time="0" />
-    <testcase name="bad_manifest_path::rustc_dir_containing_cargo_toml" time="0" />
-    <testcase name="bad_manifest_path::rustc_dir_plus_file" time="0" />
-    <testcase name="bad_manifest_path::rustc_dir_plus_path" time="0" />
-    <testcase name="bad_manifest_path::rustc_dir_to_nonexistent_cargo_toml" time="0" />
-    <testcase name="bad_manifest_path::test_dir_containing_cargo_toml" time="0" />
-    <testcase name="bad_manifest_path::test_dir_plus_file" time="0" />
-    <testcase name="bad_manifest_path::test_dir_plus_path" time="0" />
-    <testcase name="bad_manifest_path::test_dir_to_nonexistent_cargo_toml" time="0" />
-    <testcase name="bad_manifest_path::update_dir_containing_cargo_toml" time="0" />
-    <testcase name="bad_manifest_path::update_dir_plus_file" time="0" />
-    <testcase name="bad_manifest_path::update_dir_plus_path" time="0" />
-    <testcase name="bad_manifest_path::update_dir_to_nonexistent_cargo_toml" time="0" />
-    <testcase name="bad_manifest_path::verify_project_dir_containing_cargo_toml" time="0" />
-    <testcase name="bad_manifest_path::verify_project_dir_plus_file" time="0" />
-    <testcase name="bad_manifest_path::verify_project_dir_plus_path" time="0" />
-    <testcase name="bad_manifest_path::verify_project_dir_to_nonexistent_cargo_toml" time="0" />
-    <testcase name="bench::bench_all_exclude" time="0" />
-    <testcase name="bench::bench_all_virtual_manifest" time="0" />
-    <testcase name="bench::bench_all_workspace" time="0" />
-    <testcase name="bench::bench_autodiscover_2015" time="0" />
-    <testcase name="bench::bench_bench_implicit" time="0" />
-    <testcase name="bench::bench_bin_implicit" time="0" />
-    <testcase name="bench::bench_dylib" time="0" />
-    <testcase name="bench::bench_multiple_targets" time="0" />
-    <testcase name="bench::bench_tarname" time="0" />
-    <testcase name="bench::bench_twice_with_build_cmd" time="0" />
-    <testcase name="bench::bench_virtual_manifest_all_implied" time="0" />
-    <testcase name="bench::bench_with_deep_lib_dep" time="0" />
-    <testcase name="bench::bench_with_examples" time="0" />
-    <testcase name="bench::bench_with_lib_dep" time="0" />
-    <testcase name="bench::cargo_bench_failing_test" time="0" />
-    <testcase name="bench::cargo_bench_simple" time="0" />
-    <testcase name="bench::cargo_bench_twice" time="0" />
-    <testcase name="bench::dont_run_examples" time="0" />
-    <testcase name="bench::cargo_bench_verbose" time="0" />
-    <testcase name="bench::external_bench_explicit" time="0" />
-    <testcase name="bench::external_bench_implicit" time="0" />
-    <testcase name="bench::json_artifact_includes_executable_for_benchmark" time="0" />
-    <testcase name="bench::legacy_bench_name" time="0" />
-    <testcase name="bench::lib_bin_same_name" time="0" />
-    <testcase name="bench::lib_with_standard_name2" time="0" />
-    <testcase name="bench::lib_with_standard_name" time="0" />
-    <testcase name="bench::many_similar_names" time="0" />
-    <testcase name="bench::pass_through_command_line" time="0" />
-    <testcase name="bench::test_a_bench" time="0" />
-    <testcase name="bench::test_bench_multiple_packages" time="0" />
-    <testcase name="bench::test_bench_no_fail_fast" time="0" />
-    <testcase name="bench::test_bench_no_run" time="0" />
-    <testcase name="build::bad_cargo_config" time="0" />
-    <testcase name="build::bad_platform_specific_dependency" time="0" />
-    <testcase name="build::bad_cargo_toml_in_target_dir" time="0" />
-    <testcase name="build::all_targets_no_lib" time="0" />
-    <testcase name="build::avoid_dev_deps" time="0" />
-    <testcase name="build::build_all_exclude" time="0" />
-    <testcase name="build::build_all_virtual_manifest" time="0" />
-    <testcase name="build::build_all_member_dependency_same_name" time="0" />
-    <testcase name="build::build_all_virtual_manifest_implicit_examples" time="0" />
-    <testcase name="build::build_all_workspace" time="0" />
-    <testcase name="build::build_all_workspace_implicit_examples" time="0" />
-    <testcase name="build::build_virtual_manifest_all_implied" time="0" />
-    <testcase name="build::build_virtual_manifest_one_project" time="0" />
-    <testcase name="build::build_multiple_packages" time="0" />
-    <testcase name="build::cargo_build_empty_target" time="0" />
-    <testcase name="build::build_with_fake_libc_not_loading" time="0" />
-    <testcase name="build::building_a_dependent_crate_witout_bin_should_fail" time="0" />
-    <testcase name="build::cargo_compile_manifest_path" time="0" />
-    <testcase name="build::cargo_compile_offline_not_try_update" time="0" />
-    <testcase name="build::cargo_compile_duplicate_build_targets" time="0" />
-    <testcase name="build::build_filter_infer_profile" time="0" />
-    <testcase name="build::cargo_compile_with_bin_and_crate_type" time="0" />
-    <testcase name="build::cargo_compile_with_bin_and_proc" time="0" />
-    <testcase name="build::cargo_compile_incremental" time="0" />
-    <testcase name="build::cargo_compile_with_dep_name_mismatch" time="0" />
-    <testcase name="build::cargo_compile_with_empty_package_name" time="0" />
-    <testcase name="build::cargo_compile_path_with_offline" time="0" />
-    <testcase name="build::cargo_compile_with_forbidden_bin_target_name" time="0" />
-    <testcase name="build::cargo_compile_with_invalid_bin_target_name" time="0" />
-    <testcase name="build::cargo_compile_simple" time="0" />
-    <testcase name="build::cargo_compile_with_filename" time="0" />
-    <testcase name="build::cargo_compile_with_invalid_lib_target_name" time="0" />
-    <testcase name="build::cargo_compile_with_invalid_manifest" time="0" />
-    <testcase name="build::cargo_compile_with_invalid_manifest2" time="0" />
-    <testcase name="build::cargo_compile_with_invalid_manifest3" time="0" />
-    <testcase name="build::cargo_compile_with_invalid_non_numeric_dep_version" time="0" />
-    <testcase name="build::cargo_compile_with_invalid_code" time="0" />
-    <testcase name="build::cargo_compile_with_invalid_package_name" time="0" />
-    <testcase name="build::cargo_compile_with_invalid_code_in_deps" time="0" />
-    <testcase name="build::cargo_compile_with_invalid_version" time="0" />
-    <testcase name="build::cargo_compile_with_downloaded_dependency_with_offline" time="0" />
-    <testcase name="build::cargo_compile_with_nested_deps_inferred" time="0" />
-    <testcase name="build::cargo_compile_with_nested_deps_longhand" time="0" />
-    <testcase name="build::cargo_compile_with_nested_deps_correct_bin" time="0" />
-    <testcase name="build::cargo_compile_with_workspace_excluded" time="0" />
-    <testcase name="build::cargo_compile_without_manifest" time="0" />
-    <testcase name="build::cargo_compile_with_nested_deps_shorthand" time="0" />
-    <testcase name="build::cargo_compile_with_warnings_in_the_root_package" time="0" />
-    <testcase name="build::cargo_compile_with_warnings_in_a_dep_package" time="0" />
-    <testcase name="build::cargo_fail_with_no_stderr" time="0" />
-    <testcase name="build::cargo_platform_specific_dependency_wrong_platform" time="0" />
-    <testcase name="build::cargo_default_env_metadata_env_var" time="0" />
-    <testcase name="build::cdylib_final_outputs" time="0" />
-    <testcase name="build::cdylib_not_lifted" time="0" />
-    <testcase name="build::compile_offline_while_transitive_dep_not_cached" time="0" />
-    <testcase name="build::cargo_platform_specific_dependency" time="0" />
-    <testcase name="build::compile_path_dep_then_change_version" time="0" />
-    <testcase name="build::compile_then_delete" time="0" />
-    <testcase name="build::compile_offline_without_maxvers_cached" time="0" />
-    <testcase name="build::compiler_json_error_format" time="0" />
-    <testcase name="build::crate_library_path_env_var" time="0" />
-    <testcase name="build::crate_authors_env_vars" time="0" />
-    <testcase name="build::cyclic_deps_rejected" time="0" />
-    <testcase name="build::dashes_in_crate_name_bad" time="0" />
-    <testcase name="build::crate_env_vars" time="0" />
-    <testcase name="build::dashes_to_underscores" time="0" />
-    <testcase name="build::deletion_causes_failure" time="0" />
-    <testcase name="build::dep_no_libs" time="0" />
-    <testcase name="build::custom_target_dir_env" time="0" />
-    <testcase name="build::dotdir_root" time="0" />
-    <testcase name="build::deterministic_cfg_flags" time="0" />
-    <testcase name="build::example_as_proc_macro" time="0" />
-    <testcase name="build::example_as_dylib" time="0" />
-    <testcase name="build::custom_target_dir_line_parameter" time="0" />
-    <testcase name="build::example_as_lib" time="0" />
-    <testcase name="build::example_as_rlib" time="0" />
-    <testcase name="build::explicit_bins_without_paths" time="0" />
-    <testcase name="build::example_bin_same_name" time="0" />
-    <testcase name="build::explicit_color_config_is_propagated_to_rustc" time="0" />
-    <testcase name="build::explicit_examples" time="0" />
-    <testcase name="build::filtering" time="0" />
-    <testcase name="build::ignore_broken_symlinks" time="0" />
-    <testcase name="build::filtering_implicit_bins" time="0" />
-    <testcase name="build::filtering_implicit_examples" time="0" />
-    <testcase name="build::ignore_dotdirs" time="0" />
-    <testcase name="build::ignore_dotfile" time="0" />
-    <testcase name="build::freshness_ignores_excluded" time="0" />
-    <testcase name="build::ignores_carriage_return_in_lockfile" time="0" />
-    <testcase name="build::incompatible_dependencies" time="0" />
-    <testcase name="build::incompatible_dependencies_with_multi_semver" time="0" />
-    <testcase name="build::implicit_examples" time="0" />
-    <testcase name="build::incremental_config" time="0" />
-    <testcase name="build::inferred_bin_path" time="0" />
-    <testcase name="build::inferred_bins_duplicate_name" time="0" />
-    <testcase name="build::inferred_benchmarks" time="0" />
-    <testcase name="build::inferred_bins" time="0" />
-    <testcase name="build::inferred_examples" time="0" />
-    <testcase name="build::invalid_jobs" time="0" />
-    <testcase name="build::inferred_main_bin" time="0" />
-    <testcase name="build::invalid_spec" time="0" />
-    <testcase name="build::incremental_profile" time="0" />
-    <testcase name="build::inferred_tests" time="0" />
-    <testcase name="build::json_parse_fail" time="0" />
-    <testcase name="build::lib_with_standard_name" time="0" />
-    <testcase name="build::manifest_with_bom_is_ok" time="0" />
-    <testcase name="build::many_crate_types_correct" time="0" />
-    <testcase name="build::many_crate_types_old_style_lib_location" time="0" />
-    <testcase name="build::legacy_binary_paths_warnings" time="0" />
-    <testcase name="build::missing_lib_and_bin" time="0" />
-    <testcase name="build::no_bin_in_src_with_lib" time="0" />
-    <testcase name="build::message_format_json_forward_stderr" time="0" />
-    <testcase name="build::non_existing_binary" time="0" />
-    <testcase name="build::non_existing_example" time="0" />
-    <testcase name="build::no_warn_about_package_metadata" time="0" />
-    <testcase name="build::no_linkable_target" time="0" />
-    <testcase name="build::opt_out_of_bin" time="0" />
-    <testcase name="build::panic_abort_compiles_with_panic_abort" time="0" />
-    <testcase name="build::recompile_space_in_name" time="0" />
-    <testcase name="build::lto_build" time="0" />
-    <testcase name="build::predictable_filenames" time="0" />
-    <testcase name="build::rebuild_preserves_out_dir" time="0" />
-    <testcase name="build::release_build_ndebug" time="0" />
-    <testcase name="build::run_proper_alias_binary_from_src" time="0" />
-    <testcase name="build::run_proper_alias_binary_main_rs" time="0" />
-    <testcase name="build::rustc_env_var" time="0" />
-    <testcase name="build::rustc_wrapper" time="0" />
-    <testcase name="build::run_proper_binary" time="0" />
-    <testcase name="build::self_dependency" time="0" />
-    <testcase name="build::run_proper_binary_main_rs_as_foo" time="0" />
-    <testcase name="build::run_proper_binary_main_rs" time="0" />
-    <testcase name="build::simple_staticlib" time="0" />
-    <testcase name="build::single_lib" time="0" />
-    <testcase name="build::standard_build_no_ndebug" time="0" />
-    <testcase name="build::target_edition" time="0" />
-    <testcase name="build::same_metadata_different_directory" time="0" />
-    <testcase name="build::target_filters_workspace_not_found" time="0" />
-    <testcase name="build::staticlib_rlib_and_bin" time="0" />
-    <testcase name="build::target_edition_override" time="0" />
-    <testcase name="build::targets_selected_all" time="0" />
-    <testcase name="build::uplift_dsym_of_bin_on_mac" time="0" />
-    <testcase name="build::targets_selected_default" time="0" />
-    <testcase name="build::target_filters_workspace" time="0" />
-    <testcase name="build::transitive_dependencies_not_available" time="0" />
-    <testcase name="build::verbose_build" time="0" />
-    <testcase name="build::verbose_release_build" time="0" />
-    <testcase name="build::wrong_message_format_option" time="0" />
-    <testcase name="build::verbose_release_build_deps" time="0" />
-    <testcase name="build::uplift_pdb_of_bin_on_windows" time="0" />
-    <testcase name="build::vv_prints_rustc_env_vars" time="0" />
-    <testcase name="build_auth::ssh_something_happens" time="0" />
-    <testcase name="build_lib::build_with_no_lib" time="0" />
-    <testcase name="build_auth::http_auth_offered" time="0">
+    <testcase name="alt_reg_metadata" classname="alt_registry" time="0" />
+    <testcase name="cannot_publish_to_crates_io_with_registry_dependency" classname="alt_registry" time="0" />
+    <testcase name="alt_registry_and_crates_io_deps" classname="alt_registry" time="0" />
+    <testcase name="block_publish_due_to_no_token" classname="alt_registry" time="0" />
+    <testcase name="depend_on_alt_registry_depends_on_crates_io" classname="alt_registry" time="0" />
+    <testcase name="depend_on_alt_registry" classname="alt_registry" time="0" />
+    <testcase name="is_feature_gated" classname="alt_registry" time="0" />
+    <testcase name="depend_on_alt_registry_depends_on_same_registry" classname="alt_registry" time="0" />
+    <testcase name="depend_on_alt_registry_depends_on_same_registry_no_index" classname="alt_registry" time="0" />
+    <testcase name="passwords_in_url_forbidden" classname="alt_registry" time="0" />
+    <testcase name="patch_alt_reg" classname="alt_registry" time="0" />
+    <testcase name="no_api" classname="alt_registry" time="0" />
+    <testcase name="publish_to_alt_registry" classname="alt_registry" time="0" />
+    <testcase name="registry_incompatible_with_git" classname="alt_registry" time="0" />
+    <testcase name="publish_with_crates_io_dep" classname="alt_registry" time="0" />
+    <testcase name="registry_and_path_dep_works" classname="alt_registry" time="0" />
+    <testcase name="publish_with_registry_dependency" classname="alt_registry" time="0" />
+    <testcase name="bad1" classname="bad_config" time="0" />
+    <testcase name="bad2" classname="bad_config" time="0" />
+    <testcase name="bad4" classname="bad_config" time="0" />
+    <testcase name="bad3" classname="bad_config" time="0" />
+    <testcase name="bad6" classname="bad_config" time="0" />
+    <testcase name="bad_cargo_config_jobs" classname="bad_config" time="0" />
+    <testcase name="bad_cargo_lock" classname="bad_config" time="0" />
+    <testcase name="bad_debuginfo" classname="bad_config" time="0" />
+    <testcase name="bad_dependency" classname="bad_config" time="0" />
+    <testcase name="unknown_registry" classname="alt_registry" time="0" />
+    <testcase name="bad_git_dependency" classname="bad_config" time="0" />
+    <testcase name="bad_crate_type" classname="bad_config" time="0" />
+    <testcase name="bad_opt_level" classname="bad_config" time="0" />
+    <testcase name="bad_source_config1" classname="bad_config" time="0" />
+    <testcase name="bad_source_config2" classname="bad_config" time="0" />
+    <testcase name="bad_source_config3" classname="bad_config" time="0" />
+    <testcase name="bad_source_config4" classname="bad_config" time="0" />
+    <testcase name="bad_dependency_in_lockfile" classname="bad_config" time="0" />
+    <testcase name="bad_source_config5" classname="bad_config" time="0" />
+    <testcase name="bad_source_config6" classname="bad_config" time="0" />
+    <testcase name="bad_source_in_cargo_lock" classname="bad_config" time="0" />
+    <testcase name="bad_source_config7" classname="bad_config" time="0" />
+    <testcase name="duplicate_bench_names" classname="bad_config" time="0" />
+    <testcase name="duplicate_binary_names" classname="bad_config" time="0" />
+    <testcase name="duplicate_deps" classname="bad_config" time="0" />
+    <testcase name="duplicate_deps_diff_sources" classname="bad_config" time="0" />
+    <testcase name="duplicate_example_names" classname="bad_config" time="0" />
+    <testcase name="default_cargo_config_jobs" classname="bad_config" time="0" />
+    <testcase name="ambiguous_git_reference" classname="bad_config" time="0" />
+    <testcase name="duplicate_packages_in_cargo_lock" classname="bad_config" time="0" />
+    <testcase name="ignored_git_revision" classname="bad_config" time="0" />
+    <testcase name="invalid_global_config" classname="bad_config" time="0" />
+    <testcase name="good_cargo_config_jobs" classname="bad_config" time="0" />
+    <testcase name="malformed_override" classname="bad_config" time="0" />
+    <testcase name="invalid_toml_historically_allowed_is_warned" classname="bad_config" time="0" />
+    <testcase name="empty_dependencies" classname="bad_config" time="0" />
+    <testcase name="bench_dir_containing_cargo_toml" classname="bad_manifest_path" time="0" />
+    <testcase name="bench_dir_plus_file" classname="bad_manifest_path" time="0" />
+    <testcase name="bench_dir_plus_path" classname="bad_manifest_path" time="0" />
+    <testcase name="bench_dir_to_nonexistent_cargo_toml" classname="bad_manifest_path" time="0" />
+    <testcase name="build_dir_containing_cargo_toml" classname="bad_manifest_path" time="0" />
+    <testcase name="unused_keys_in_virtual_manifest" classname="bad_config" time="0" />
+    <testcase name="build_dir_plus_file" classname="bad_manifest_path" time="0" />
+    <testcase name="build_dir_plus_path" classname="bad_manifest_path" time="0" />
+    <testcase name="build_dir_to_nonexistent_cargo_toml" classname="bad_manifest_path" time="0" />
+    <testcase name="clean_dir_containing_cargo_toml" classname="bad_manifest_path" time="0" />
+    <testcase name="clean_dir_plus_file" classname="bad_manifest_path" time="0" />
+    <testcase name="clean_dir_plus_path" classname="bad_manifest_path" time="0" />
+    <testcase name="clean_dir_to_nonexistent_cargo_toml" classname="bad_manifest_path" time="0" />
+    <testcase name="doc_dir_containing_cargo_toml" classname="bad_manifest_path" time="0" />
+    <testcase name="doc_dir_plus_file" classname="bad_manifest_path" time="0" />
+    <testcase name="doc_dir_plus_path" classname="bad_manifest_path" time="0" />
+    <testcase name="doc_dir_to_nonexistent_cargo_toml" classname="bad_manifest_path" time="0" />
+    <testcase name="fetch_dir_containing_cargo_toml" classname="bad_manifest_path" time="0" />
+    <testcase name="fetch_dir_plus_file" classname="bad_manifest_path" time="0" />
+    <testcase name="both_git_and_path_specified" classname="bad_config" time="0" />
+    <testcase name="fetch_dir_plus_path" classname="bad_manifest_path" time="0" />
+    <testcase name="fetch_dir_to_nonexistent_cargo_toml" classname="bad_manifest_path" time="0" />
+    <testcase name="generate_lockfile_dir_plus_file" classname="bad_manifest_path" time="0" />
+    <testcase name="generate_lockfile_dir_containing_cargo_toml" classname="bad_manifest_path" time="0" />
+    <testcase name="generate_lockfile_dir_plus_path" classname="bad_manifest_path" time="0" />
+    <testcase name="generate_lockfile_dir_to_nonexistent_cargo_toml" classname="bad_manifest_path" time="0" />
+    <testcase name="package_dir_containing_cargo_toml" classname="bad_manifest_path" time="0" />
+    <testcase name="package_dir_plus_file" classname="bad_manifest_path" time="0" />
+    <testcase name="package_dir_plus_path" classname="bad_manifest_path" time="0" />
+    <testcase name="package_dir_to_nonexistent_cargo_toml" classname="bad_manifest_path" time="0" />
+    <testcase name="pkgid_dir_containing_cargo_toml" classname="bad_manifest_path" time="0" />
+    <testcase name="pkgid_dir_plus_file" classname="bad_manifest_path" time="0" />
+    <testcase name="pkgid_dir_plus_path" classname="bad_manifest_path" time="0" />
+    <testcase name="pkgid_dir_to_nonexistent_cargo_toml" classname="bad_manifest_path" time="0" />
+    <testcase name="publish_dir_containing_cargo_toml" classname="bad_manifest_path" time="0" />
+    <testcase name="publish_dir_plus_file" classname="bad_manifest_path" time="0" />
+    <testcase name="publish_dir_plus_path" classname="bad_manifest_path" time="0" />
+    <testcase name="publish_dir_to_nonexistent_cargo_toml" classname="bad_manifest_path" time="0" />
+    <testcase name="read_manifest_dir_containing_cargo_toml" classname="bad_manifest_path" time="0" />
+    <testcase name="read_manifest_dir_plus_file" classname="bad_manifest_path" time="0" />
+    <testcase name="read_manifest_dir_plus_path" classname="bad_manifest_path" time="0" />
+    <testcase name="read_manifest_dir_to_nonexistent_cargo_toml" classname="bad_manifest_path" time="0" />
+    <testcase name="run_dir_containing_cargo_toml" classname="bad_manifest_path" time="0" />
+    <testcase name="run_dir_plus_file" classname="bad_manifest_path" time="0" />
+    <testcase name="run_dir_plus_path" classname="bad_manifest_path" time="0" />
+    <testcase name="run_dir_to_nonexistent_cargo_toml" classname="bad_manifest_path" time="0" />
+    <testcase name="unused_keys" classname="bad_config" time="0" />
+    <testcase name="rustc_dir_containing_cargo_toml" classname="bad_manifest_path" time="0" />
+    <testcase name="rustc_dir_plus_file" classname="bad_manifest_path" time="0" />
+    <testcase name="rustc_dir_plus_path" classname="bad_manifest_path" time="0" />
+    <testcase name="rustc_dir_to_nonexistent_cargo_toml" classname="bad_manifest_path" time="0" />
+    <testcase name="test_dir_containing_cargo_toml" classname="bad_manifest_path" time="0" />
+    <testcase name="test_dir_plus_file" classname="bad_manifest_path" time="0" />
+    <testcase name="test_dir_plus_path" classname="bad_manifest_path" time="0" />
+    <testcase name="test_dir_to_nonexistent_cargo_toml" classname="bad_manifest_path" time="0" />
+    <testcase name="update_dir_containing_cargo_toml" classname="bad_manifest_path" time="0" />
+    <testcase name="update_dir_plus_file" classname="bad_manifest_path" time="0" />
+    <testcase name="update_dir_plus_path" classname="bad_manifest_path" time="0" />
+    <testcase name="update_dir_to_nonexistent_cargo_toml" classname="bad_manifest_path" time="0" />
+    <testcase name="verify_project_dir_containing_cargo_toml" classname="bad_manifest_path" time="0" />
+    <testcase name="verify_project_dir_plus_file" classname="bad_manifest_path" time="0" />
+    <testcase name="verify_project_dir_plus_path" classname="bad_manifest_path" time="0" />
+    <testcase name="verify_project_dir_to_nonexistent_cargo_toml" classname="bad_manifest_path" time="0" />
+    <testcase name="bench_all_exclude" classname="bench" time="0" />
+    <testcase name="bench_all_virtual_manifest" classname="bench" time="0" />
+    <testcase name="bench_all_workspace" classname="bench" time="0" />
+    <testcase name="bench_autodiscover_2015" classname="bench" time="0" />
+    <testcase name="bench_bench_implicit" classname="bench" time="0" />
+    <testcase name="bench_bin_implicit" classname="bench" time="0" />
+    <testcase name="bench_dylib" classname="bench" time="0" />
+    <testcase name="bench_multiple_targets" classname="bench" time="0" />
+    <testcase name="bench_tarname" classname="bench" time="0" />
+    <testcase name="bench_twice_with_build_cmd" classname="bench" time="0" />
+    <testcase name="bench_virtual_manifest_all_implied" classname="bench" time="0" />
+    <testcase name="bench_with_deep_lib_dep" classname="bench" time="0" />
+    <testcase name="bench_with_examples" classname="bench" time="0" />
+    <testcase name="bench_with_lib_dep" classname="bench" time="0" />
+    <testcase name="cargo_bench_failing_test" classname="bench" time="0" />
+    <testcase name="cargo_bench_simple" classname="bench" time="0" />
+    <testcase name="cargo_bench_twice" classname="bench" time="0" />
+    <testcase name="dont_run_examples" classname="bench" time="0" />
+    <testcase name="cargo_bench_verbose" classname="bench" time="0" />
+    <testcase name="external_bench_explicit" classname="bench" time="0" />
+    <testcase name="external_bench_implicit" classname="bench" time="0" />
+    <testcase name="json_artifact_includes_executable_for_benchmark" classname="bench" time="0" />
+    <testcase name="legacy_bench_name" classname="bench" time="0" />
+    <testcase name="lib_bin_same_name" classname="bench" time="0" />
+    <testcase name="lib_with_standard_name2" classname="bench" time="0" />
+    <testcase name="lib_with_standard_name" classname="bench" time="0" />
+    <testcase name="many_similar_names" classname="bench" time="0" />
+    <testcase name="pass_through_command_line" classname="bench" time="0" />
+    <testcase name="test_a_bench" classname="bench" time="0" />
+    <testcase name="test_bench_multiple_packages" classname="bench" time="0" />
+    <testcase name="test_bench_no_fail_fast" classname="bench" time="0" />
+    <testcase name="test_bench_no_run" classname="bench" time="0" />
+    <testcase name="bad_cargo_config" classname="build" time="0" />
+    <testcase name="bad_platform_specific_dependency" classname="build" time="0" />
+    <testcase name="bad_cargo_toml_in_target_dir" classname="build" time="0" />
+    <testcase name="all_targets_no_lib" classname="build" time="0" />
+    <testcase name="avoid_dev_deps" classname="build" time="0" />
+    <testcase name="build_all_exclude" classname="build" time="0" />
+    <testcase name="build_all_virtual_manifest" classname="build" time="0" />
+    <testcase name="build_all_member_dependency_same_name" classname="build" time="0" />
+    <testcase name="build_all_virtual_manifest_implicit_examples" classname="build" time="0" />
+    <testcase name="build_all_workspace" classname="build" time="0" />
+    <testcase name="build_all_workspace_implicit_examples" classname="build" time="0" />
+    <testcase name="build_virtual_manifest_all_implied" classname="build" time="0" />
+    <testcase name="build_virtual_manifest_one_project" classname="build" time="0" />
+    <testcase name="build_multiple_packages" classname="build" time="0" />
+    <testcase name="cargo_build_empty_target" classname="build" time="0" />
+    <testcase name="build_with_fake_libc_not_loading" classname="build" time="0" />
+    <testcase name="building_a_dependent_crate_witout_bin_should_fail" classname="build" time="0" />
+    <testcase name="cargo_compile_manifest_path" classname="build" time="0" />
+    <testcase name="cargo_compile_offline_not_try_update" classname="build" time="0" />
+    <testcase name="cargo_compile_duplicate_build_targets" classname="build" time="0" />
+    <testcase name="build_filter_infer_profile" classname="build" time="0" />
+    <testcase name="cargo_compile_with_bin_and_crate_type" classname="build" time="0" />
+    <testcase name="cargo_compile_with_bin_and_proc" classname="build" time="0" />
+    <testcase name="cargo_compile_incremental" classname="build" time="0" />
+    <testcase name="cargo_compile_with_dep_name_mismatch" classname="build" time="0" />
+    <testcase name="cargo_compile_with_empty_package_name" classname="build" time="0" />
+    <testcase name="cargo_compile_path_with_offline" classname="build" time="0" />
+    <testcase name="cargo_compile_with_forbidden_bin_target_name" classname="build" time="0" />
+    <testcase name="cargo_compile_with_invalid_bin_target_name" classname="build" time="0" />
+    <testcase name="cargo_compile_simple" classname="build" time="0" />
+    <testcase name="cargo_compile_with_filename" classname="build" time="0" />
+    <testcase name="cargo_compile_with_invalid_lib_target_name" classname="build" time="0" />
+    <testcase name="cargo_compile_with_invalid_manifest" classname="build" time="0" />
+    <testcase name="cargo_compile_with_invalid_manifest2" classname="build" time="0" />
+    <testcase name="cargo_compile_with_invalid_manifest3" classname="build" time="0" />
+    <testcase name="cargo_compile_with_invalid_non_numeric_dep_version" classname="build" time="0" />
+    <testcase name="cargo_compile_with_invalid_code" classname="build" time="0" />
+    <testcase name="cargo_compile_with_invalid_package_name" classname="build" time="0" />
+    <testcase name="cargo_compile_with_invalid_code_in_deps" classname="build" time="0" />
+    <testcase name="cargo_compile_with_invalid_version" classname="build" time="0" />
+    <testcase name="cargo_compile_with_downloaded_dependency_with_offline" classname="build" time="0" />
+    <testcase name="cargo_compile_with_nested_deps_inferred" classname="build" time="0" />
+    <testcase name="cargo_compile_with_nested_deps_longhand" classname="build" time="0" />
+    <testcase name="cargo_compile_with_nested_deps_correct_bin" classname="build" time="0" />
+    <testcase name="cargo_compile_with_workspace_excluded" classname="build" time="0" />
+    <testcase name="cargo_compile_without_manifest" classname="build" time="0" />
+    <testcase name="cargo_compile_with_nested_deps_shorthand" classname="build" time="0" />
+    <testcase name="cargo_compile_with_warnings_in_the_root_package" classname="build" time="0" />
+    <testcase name="cargo_compile_with_warnings_in_a_dep_package" classname="build" time="0" />
+    <testcase name="cargo_fail_with_no_stderr" classname="build" time="0" />
+    <testcase name="cargo_platform_specific_dependency_wrong_platform" classname="build" time="0" />
+    <testcase name="cargo_default_env_metadata_env_var" classname="build" time="0" />
+    <testcase name="cdylib_final_outputs" classname="build" time="0" />
+    <testcase name="cdylib_not_lifted" classname="build" time="0" />
+    <testcase name="compile_offline_while_transitive_dep_not_cached" classname="build" time="0" />
+    <testcase name="cargo_platform_specific_dependency" classname="build" time="0" />
+    <testcase name="compile_path_dep_then_change_version" classname="build" time="0" />
+    <testcase name="compile_then_delete" classname="build" time="0" />
+    <testcase name="compile_offline_without_maxvers_cached" classname="build" time="0" />
+    <testcase name="compiler_json_error_format" classname="build" time="0" />
+    <testcase name="crate_library_path_env_var" classname="build" time="0" />
+    <testcase name="crate_authors_env_vars" classname="build" time="0" />
+    <testcase name="cyclic_deps_rejected" classname="build" time="0" />
+    <testcase name="dashes_in_crate_name_bad" classname="build" time="0" />
+    <testcase name="crate_env_vars" classname="build" time="0" />
+    <testcase name="dashes_to_underscores" classname="build" time="0" />
+    <testcase name="deletion_causes_failure" classname="build" time="0" />
+    <testcase name="dep_no_libs" classname="build" time="0" />
+    <testcase name="custom_target_dir_env" classname="build" time="0" />
+    <testcase name="dotdir_root" classname="build" time="0" />
+    <testcase name="deterministic_cfg_flags" classname="build" time="0" />
+    <testcase name="example_as_proc_macro" classname="build" time="0" />
+    <testcase name="example_as_dylib" classname="build" time="0" />
+    <testcase name="custom_target_dir_line_parameter" classname="build" time="0" />
+    <testcase name="example_as_lib" classname="build" time="0" />
+    <testcase name="example_as_rlib" classname="build" time="0" />
+    <testcase name="explicit_bins_without_paths" classname="build" time="0" />
+    <testcase name="example_bin_same_name" classname="build" time="0" />
+    <testcase name="explicit_color_config_is_propagated_to_rustc" classname="build" time="0" />
+    <testcase name="explicit_examples" classname="build" time="0" />
+    <testcase name="filtering" classname="build" time="0" />
+    <testcase name="ignore_broken_symlinks" classname="build" time="0" />
+    <testcase name="filtering_implicit_bins" classname="build" time="0" />
+    <testcase name="filtering_implicit_examples" classname="build" time="0" />
+    <testcase name="ignore_dotdirs" classname="build" time="0" />
+    <testcase name="ignore_dotfile" classname="build" time="0" />
+    <testcase name="freshness_ignores_excluded" classname="build" time="0" />
+    <testcase name="ignores_carriage_return_in_lockfile" classname="build" time="0" />
+    <testcase name="incompatible_dependencies" classname="build" time="0" />
+    <testcase name="incompatible_dependencies_with_multi_semver" classname="build" time="0" />
+    <testcase name="implicit_examples" classname="build" time="0" />
+    <testcase name="incremental_config" classname="build" time="0" />
+    <testcase name="inferred_bin_path" classname="build" time="0" />
+    <testcase name="inferred_bins_duplicate_name" classname="build" time="0" />
+    <testcase name="inferred_benchmarks" classname="build" time="0" />
+    <testcase name="inferred_bins" classname="build" time="0" />
+    <testcase name="inferred_examples" classname="build" time="0" />
+    <testcase name="invalid_jobs" classname="build" time="0" />
+    <testcase name="inferred_main_bin" classname="build" time="0" />
+    <testcase name="invalid_spec" classname="build" time="0" />
+    <testcase name="incremental_profile" classname="build" time="0" />
+    <testcase name="inferred_tests" classname="build" time="0" />
+    <testcase name="json_parse_fail" classname="build" time="0" />
+    <testcase name="lib_with_standard_name" classname="build" time="0" />
+    <testcase name="manifest_with_bom_is_ok" classname="build" time="0" />
+    <testcase name="many_crate_types_correct" classname="build" time="0" />
+    <testcase name="many_crate_types_old_style_lib_location" classname="build" time="0" />
+    <testcase name="legacy_binary_paths_warnings" classname="build" time="0" />
+    <testcase name="missing_lib_and_bin" classname="build" time="0" />
+    <testcase name="no_bin_in_src_with_lib" classname="build" time="0" />
+    <testcase name="message_format_json_forward_stderr" classname="build" time="0" />
+    <testcase name="non_existing_binary" classname="build" time="0" />
+    <testcase name="non_existing_example" classname="build" time="0" />
+    <testcase name="no_warn_about_package_metadata" classname="build" time="0" />
+    <testcase name="no_linkable_target" classname="build" time="0" />
+    <testcase name="opt_out_of_bin" classname="build" time="0" />
+    <testcase name="panic_abort_compiles_with_panic_abort" classname="build" time="0" />
+    <testcase name="recompile_space_in_name" classname="build" time="0" />
+    <testcase name="lto_build" classname="build" time="0" />
+    <testcase name="predictable_filenames" classname="build" time="0" />
+    <testcase name="rebuild_preserves_out_dir" classname="build" time="0" />
+    <testcase name="release_build_ndebug" classname="build" time="0" />
+    <testcase name="run_proper_alias_binary_from_src" classname="build" time="0" />
+    <testcase name="run_proper_alias_binary_main_rs" classname="build" time="0" />
+    <testcase name="rustc_env_var" classname="build" time="0" />
+    <testcase name="rustc_wrapper" classname="build" time="0" />
+    <testcase name="run_proper_binary" classname="build" time="0" />
+    <testcase name="self_dependency" classname="build" time="0" />
+    <testcase name="run_proper_binary_main_rs_as_foo" classname="build" time="0" />
+    <testcase name="run_proper_binary_main_rs" classname="build" time="0" />
+    <testcase name="simple_staticlib" classname="build" time="0" />
+    <testcase name="single_lib" classname="build" time="0" />
+    <testcase name="standard_build_no_ndebug" classname="build" time="0" />
+    <testcase name="target_edition" classname="build" time="0" />
+    <testcase name="same_metadata_different_directory" classname="build" time="0" />
+    <testcase name="target_filters_workspace_not_found" classname="build" time="0" />
+    <testcase name="staticlib_rlib_and_bin" classname="build" time="0" />
+    <testcase name="target_edition_override" classname="build" time="0" />
+    <testcase name="targets_selected_all" classname="build" time="0" />
+    <testcase name="uplift_dsym_of_bin_on_mac" classname="build" time="0" />
+    <testcase name="targets_selected_default" classname="build" time="0" />
+    <testcase name="target_filters_workspace" classname="build" time="0" />
+    <testcase name="transitive_dependencies_not_available" classname="build" time="0" />
+    <testcase name="verbose_build" classname="build" time="0" />
+    <testcase name="verbose_release_build" classname="build" time="0" />
+    <testcase name="wrong_message_format_option" classname="build" time="0" />
+    <testcase name="verbose_release_build_deps" classname="build" time="0" />
+    <testcase name="uplift_pdb_of_bin_on_windows" classname="build" time="0" />
+    <testcase name="vv_prints_rustc_env_vars" classname="build" time="0" />
+    <testcase name="ssh_something_happens" classname="build_auth" time="0" />
+    <testcase name="build_with_no_lib" classname="build_lib" time="0" />
+    <testcase name="http_auth_offered" classname="build_auth" time="0">
       <failure type="cargo test" message="running `C:\src\rust-lang\cargo\target\debug\cargo.exe build -v`&#xA;running `C:\src\rust-lang\cargo\target\debug\cargo.exe build`&#xA;thread &apos;build_auth::http_auth_offered&apos; panicked at &apos;&#xA;Expected: execs&#xA;    but: expected to find:&#xA;[UPDATING] git repository `http://127.0.0.1:33960/foo/bar`&#xA;[ERROR] failed to load source for a dependency on `bar`&#xA;&#xA;Caused by:&#xA;  Unable to update http://127.0.0.1:33960/foo/bar&#xA;&#xA;Caused by:&#xA;  failed to clone into: [..]&#xA;&#xA;Caused by:&#xA;  failed to authenticate when downloading repository&#xA;attempted to find username/password via `credential.helper`, but [..]&#xA;&#xA;Caused by:&#xA;&#xA;&#xA;did not find in output:&#xA;    Updating git repository `http://127.0.0.1:33960/foo/bar`&#xA;error: failed to load source for a dependency on `bar`&#xA;&#xA;Caused by:&#xA;  Unable to update http://127.0.0.1:33960/foo/bar&#xA;&#xA;Caused by:&#xA;  failed to clone into: C:\src\rust-lang\cargo\target\cit\t263\home\.cargo\git\db\bar-8cbd35f4772f62e3&#xA;&#xA;Caused by:&#xA;  failed to authenticate when downloading repository&#xA;attempted to find username/password via git&apos;s `credential.helper` support, but failed&#xA;&#xA;Caused by:&#xA;  failed to acquire username/password from local configuration&#xA;&apos;, tests\testsuite\support\mod.rs:794:13&#xA;" />
     </testcase>
-    <testcase name="build_lib::build_lib_only" time="0" />
-    <testcase name="build_auth::https_something_happens" time="0" />
-    <testcase name="build_plan::cargo_build_plan_build_script" time="0" />
-    <testcase name="build_lib::build_with_relative_cargo_home_path" time="0" />
-    <testcase name="build_plan::cargo_build_plan_simple" time="0" />
-    <testcase name="build_plan::build_plan_with_dev_dep" time="0" />
-    <testcase name="build_plan::cargo_build_plan_single_dep" time="0" />
-    <testcase name="build_script::adding_an_override_invalidates" time="0" />
-    <testcase name="build_script::assume_build_script_when_build_rs_present" time="0" />
-    <testcase name="build_script::build_script_only" time="0" />
-    <testcase name="build_script::build_deps_not_for_normal" time="0" />
-    <testcase name="build_script::build_cmd_with_a_build_cmd" time="0" />
-    <testcase name="build_script::build_deps_simple" time="0" />
-    <testcase name="build_script::build_script_with_lto" time="0" />
-    <testcase name="build_script::cfg_feedback" time="0" />
-    <testcase name="build_script::cfg_env_vars_available" time="0" />
-    <testcase name="build_script::build_script_with_dynamic_native_dependency" time="0" />
-    <testcase name="build_script::cfg_override" time="0" />
-    <testcase name="build_script::cfg_override_test" time="0" />
-    <testcase name="build_script::cfg_test" time="0" />
-    <testcase name="build_script::custom_build_env_var_rustc_linker" time="0" />
-    <testcase name="build_script::changing_an_override_invalidates" time="0" />
-    <testcase name="build_script::cfg_doc" time="0" />
-    <testcase name="build_script::custom_build_script_failed" time="0" />
-    <testcase name="build_script::custom_build_script_wrong_rustc_flags" time="0" />
-    <testcase name="build_script::custom_build_env_vars" time="0" />
-    <testcase name="build_script::cfg_override_doc" time="0" />
-    <testcase name="build_script::custom_target_dir" time="0" />
-    <testcase name="build_script::diamond_passes_args_only_once" time="0" />
-    <testcase name="build_script::deterministic_rustc_dependency_flags" time="0" />
-    <testcase name="build_script::env_build" time="0" />
-    <testcase name="build_script::doctest_receives_build_link_args" time="0" />
-    <testcase name="build_script::fresh_builds_possible_with_link_libs" time="0" />
-    <testcase name="build_script::fresh_builds_possible_with_multiple_metadata_overrides" time="0" />
-    <testcase name="build_script::env_test" time="0" />
-    <testcase name="build_script::links_duplicates" time="0" />
-    <testcase name="build_script::links_duplicates_deep_dependency" time="0" />
-    <testcase name="build_script::links_duplicates_with_cycle" time="0" />
-    <testcase name="build_script::flags_go_into_tests" time="0" />
-    <testcase name="build_script::if_build_set_to_false_dont_treat_build_rs_as_build_script" time="0" />
-    <testcase name="build_script::links_no_build_cmd" time="0" />
-    <testcase name="build_script::env_doc" time="0" />
-    <testcase name="build_script::links_with_dots" time="0" />
-    <testcase name="build_script::links_passes_env_vars" time="0" />
-    <testcase name="build_script::non_utf8_output" time="0" />
-    <testcase name="build_script::only_rerun_build_script" time="0" />
-    <testcase name="build_script::output_separate_lines" time="0" />
-    <testcase name="build_script::optional_build_dep_and_required_normal_dep" time="0" />
-    <testcase name="build_script::out_dir_is_preserved" time="0" />
-    <testcase name="build_script::optional_build_script_dep" time="0" />
-    <testcase name="build_script::output_separate_lines_new" time="0" />
-    <testcase name="build_script::output_shows_on_vv" time="0" />
-    <testcase name="build_script::overrides_and_links" time="0" />
-    <testcase name="build_script::please_respect_the_dag" time="0" />
-    <testcase name="build_script::profile_debug_0" time="0" />
-    <testcase name="build_script::profile_and_opt_level_set_correctly" time="0" />
-    <testcase name="build_script::propagation_of_l_flags" time="0" />
-    <testcase name="build_script::panic_abort_with_build_scripts" time="0" />
-    <testcase name="build_script::propagation_of_l_flags_new" time="0" />
-    <testcase name="build_script::rebuild_continues_to_pass_env_vars" time="0" />
-    <testcase name="build_script::rename_with_link_search_path_cross" time="0" />
-    <testcase name="build_script::release_with_build_script" time="0" />
-    <testcase name="build_script::rustc_and_rustdoc_set_correctly" time="0" />
-    <testcase name="build_script::shared_dep_with_a_build_script" time="0" />
-    <testcase name="build_script::rename_with_link_search_path" time="0" />
-    <testcase name="build_script::rebuild_only_on_explicit_paths" time="0" />
-    <testcase name="build_script::test_dev_dep_build_script" time="0" />
-    <testcase name="build_script::switch_features_rerun" time="0" />
-    <testcase name="build_script::test_a_lib_with_a_build_command" time="0" />
-    <testcase name="build_script::test_duplicate_deps" time="0" />
-    <testcase name="build_script::unused_overrides" time="0" />
-    <testcase name="build_script::warnings_emitted" time="0" />
-    <testcase name="build_script::transitive_dep_host" time="0" />
-    <testcase name="build_script::warnings_hidden_for_upstream" time="0" />
-    <testcase name="build_script::warnings_printed_on_vv" time="0" />
-    <testcase name="cargo_alias_config::alias_cannot_shadow_builtin_command" time="0" />
-    <testcase name="build_script_env::rerun_if_env_changes" time="0" />
-    <testcase name="cargo_alias_config::alias_incorrect_config_type" time="0" />
-    <testcase name="build_script::testing_and_such" time="0" />
-    <testcase name="cargo_alias_config::alias_config" time="0" />
-    <testcase name="cargo_alias_config::alias_list_test" time="0" />
-    <testcase name="cargo_alias_config::alias_override_builtin_alias" time="0" />
-    <testcase name="cargo_alias_config::alias_with_flags_config" time="0" />
-    <testcase name="build_script_env::rerun_if_env_or_file_changes" time="0" />
-    <testcase name="cargo_command::cargo_help" time="0" />
-    <testcase name="cargo_alias_config::recursive_alias" time="0" />
-    <testcase name="cargo_alias_config::builtin_alias_takes_options" time="0" />
-    <testcase name="cargo_command::displays_subcommand_on_error" time="0" />
-    <testcase name="cargo_command::explain" time="0" />
-    <testcase name="cargo_command::cargo_subcommand_args" time="0" />
-    <testcase name="cargo_command::find_closest_dont_correct_nonsense" time="0" />
-    <testcase name="cargo_command::cargo_subcommand_env" time="0" />
-    <testcase name="cargo_command::list_command_looks_at_path" time="0" />
-    <testcase name="cargo_command::list_commands_with_descriptions" time="0" />
-    <testcase name="cargo_command::override_cargo_home" time="0" />
-    <testcase name="cargo_command::z_flags_help" time="0" />
-    <testcase name="cargo_command::cargo_help_external_subcommand" time="0" />
-    <testcase name="cargo_features::feature_required" time="0" />
-    <testcase name="cargo_features::cant_publish" time="0" />
-    <testcase name="cargo_features::nightly_feature_requires_nightly" time="0" />
-    <testcase name="cargo_features::nightly_feature_requires_nightly_in_dep" time="0" />
-    <testcase name="cargo_command::find_closest_biuld_to_build" time="0" />
-    <testcase name="cargo_features::unknown_feature" time="0" />
-    <testcase name="cargo_features::stable_feature_warns" time="0" />
-    <testcase name="cfg::bad_target_spec" time="0" />
-    <testcase name="cfg::bad_target_spec2" time="0" />
-    <testcase name="cargo_features::z_flags_rejected" time="0" />
-    <testcase name="cfg::cfg_expr" time="0" />
-    <testcase name="cfg::cfg_expr_bad" time="0" />
-    <testcase name="cfg::cfg_matches" time="0" />
-    <testcase name="cargo_features::publish_allowed" time="0" />
-    <testcase name="cfg::cfg_syntax" time="0" />
-    <testcase name="cfg::cfg_syntax_bad" time="0" />
-    <testcase name="cfg::any_ok" time="0" />
-    <testcase name="cfg::cfg_easy" time="0" />
-    <testcase name="cfg::dont_include" time="0" />
-    <testcase name="cfg::multiple_match_ok" time="0" />
-    <testcase name="cfg::ignore_version_from_other_platform" time="0" />
-    <testcase name="check::check_all" time="0" />
-    <testcase name="check::build_check" time="0" />
-    <testcase name="cfg::works_through_the_registry" time="0" />
-    <testcase name="check::check_fail" time="0" />
-    <testcase name="check::check_build" time="0" />
-    <testcase name="check::check_success" time="0" />
-    <testcase name="check::check_unit_test_profile" time="0" />
-    <testcase name="check::check_virtual_all_implied" time="0" />
-    <testcase name="check::does_not_use_empty_rustc_wrapper" time="0" />
-    <testcase name="check::custom_derive" time="0" />
-    <testcase name="check::check_artifacts" time="0" />
-    <testcase name="check::check_filters" time="0" />
-    <testcase name="check::dylib_check_preserves_build_cache" time="0" />
-    <testcase name="check::issue_3418" time="0" />
-    <testcase name="check::issue_3419" time="0" />
-    <testcase name="check::rustc_check" time="0" />
-    <testcase name="check::proc_macro" time="0" />
-    <testcase name="check::rustc_check_err" time="0" />
-    <testcase name="check::short_message_format" time="0" />
-    <testcase name="check::targets_selected_all" time="0" />
-    <testcase name="check::error_from_deep_recursion" time="0" />
-    <testcase name="check::targets_selected_default" time="0" />
-    <testcase name="clean::cargo_clean_simple" time="0" />
-    <testcase name="clean::clean_multiple_packages" time="0" />
-    <testcase name="clean::build_script" time="0" />
-    <testcase name="clean::clean_git" time="0" />
-    <testcase name="clean::different_dir" time="0" />
-    <testcase name="clean::clean_verbose" time="0" />
-    <testcase name="clean::clean_release" time="0" />
-    <testcase name="collisions::collision_example" time="0" />
-    <testcase name="clean::registry" time="0" />
-    <testcase name="collisions::collision_dylib" time="0" />
-    <testcase name="clean::clean_doc" time="0" />
-    <testcase name="collisions::collision_export" time="0" />
-    <testcase name="concurrent::concurrent_installs" time="0" />
-    <testcase name="concurrent::debug_release_ok" time="0" />
-    <testcase name="concurrent::multiple_installs" time="0" />
-    <testcase name="concurrent::git_same_repo_different_tags" time="0" />
-    <testcase name="concurrent::git_same_branch_different_revs" time="0" />
-    <testcase name="concurrent::one_install_should_be_bad" time="0" />
-    <testcase name="config::config_bad_toml" time="0" />
-    <testcase name="config::config_deserialize_any" time="0" />
-    <testcase name="config::config_get_integers" time="0" />
-    <testcase name="config::config_get_list" time="0" />
-    <testcase name="config::config_get_option" time="0" />
-    <testcase name="config::config_get_other_types" time="0" />
-    <testcase name="config::config_load_toml_profile" time="0" />
-    <testcase name="config::config_relative_path" time="0" />
-    <testcase name="config::config_toml_errors" time="0" />
-    <testcase name="config::config_unused_fields" time="0" />
-    <testcase name="config::get_config" time="0" />
-    <testcase name="config::get_errors" time="0" />
-    <testcase name="concurrent::same_project" time="0" />
-    <testcase name="config::load_nested" time="0" />
-    <testcase name="concurrent::no_deadlock_with_git_dependencies" time="0" />
-    <testcase name="concurrent::multiple_registry_fetches" time="0" />
-    <testcase name="cross_compile::build_deps_for_the_right_arch" time="0" />
-    <testcase name="cross_compile::build_script_needed_for_host_and_target" time="0" />
-    <testcase name="cross_compile::build_script_only_host" time="0" />
-    <testcase name="cross_compile::build_script_with_platform_specific_dependencies" time="0" />
-    <testcase name="cross_compile::cross_test_dylib" time="0" />
-    <testcase name="cross_compile::cross_tests" time="0" />
-    <testcase name="cross_compile::cross_with_a_build_script" time="0" />
-    <testcase name="cross_compile::linker_and_ar" time="0" />
-    <testcase name="cross_compile::no_cross_doctests" time="0" />
-    <testcase name="cross_compile::platform_specific_dependencies_do_not_leak" time="0" />
-    <testcase name="cross_compile::platform_specific_variables_reflected_in_build_scripts" time="0" />
-    <testcase name="cross_compile::plugin_build_script_right_arch" time="0" />
-    <testcase name="cross_compile::plugin_deps" time="0" />
-    <testcase name="cross_compile::plugin_to_the_max" time="0" />
-    <testcase name="cross_compile::plugin_with_extra_dylib_dep" time="0" />
-    <testcase name="cross_compile::simple_cargo_run" time="0" />
-    <testcase name="cross_compile::simple_cross" time="0" />
-    <testcase name="cross_compile::simple_cross_config" time="0" />
-    <testcase name="cross_compile::simple_deps" time="0" />
-    <testcase name="cross_publish::publish_with_target" time="0" />
-    <testcase name="cross_publish::simple_cross_package" time="0" />
-    <testcase name="custom_target::custom_target_dependency" time="0" />
-    <testcase name="custom_target::custom_target_minimal" time="0" />
-    <testcase name="config::read_env_vars_for_config" time="0" />
-    <testcase name="dep_info::build_dep_info" time="0" />
-    <testcase name="death::ctrl_c_kills_everyone" time="0" />
-    <testcase name="corrupt_git::deleting_database_files" time="0" />
-    <testcase name="dep_info::build_dep_info_lib" time="0" />
-    <testcase name="dep_info::build_dep_info_dylib" time="0" />
-    <testcase name="corrupt_git::deleting_checkout_files" time="0" />
-    <testcase name="directory::bad_file_checksum" time="0" />
-    <testcase name="dep_info::build_dep_info_rlib" time="0" />
-    <testcase name="dep_info::no_rewrite_if_no_change" time="0" />
-    <testcase name="directory::git_override_requires_lockfile" time="0" />
-    <testcase name="directory::crates_io_then_bad_checksum" time="0" />
-    <testcase name="directory::git_lock_file_doesnt_change" time="0" />
-    <testcase name="directory::install_without_feature_dep" time="0" />
-    <testcase name="directory::not_there" time="0" />
-    <testcase name="directory::crates_io_then_directory" time="0" />
-    <testcase name="directory::multiple" time="0" />
-    <testcase name="directory::only_dot_files_ok" time="0" />
-    <testcase name="directory::random_files_ok" time="0" />
-    <testcase name="directory::simple_install_fail" time="0" />
-    <testcase name="directory::simple" time="0" />
-    <testcase name="directory::version_missing" time="0" />
-    <testcase name="doc::doc_all_member_dependency_same_name" time="0" />
-    <testcase name="directory::simple_install" time="0" />
-    <testcase name="doc::doc_cap_lints" time="0" />
-    <testcase name="directory::workspace_different_locations" time="0" />
-    <testcase name="doc::doc_all_virtual_manifest" time="0" />
-    <testcase name="doc::doc_edition" time="0" />
-    <testcase name="doc::doc_all_workspace" time="0" />
-    <testcase name="doc::doc_lib_bin_same_name_documents_bins_when_requested" time="0" />
-    <testcase name="doc::doc_dash_p" time="0" />
-    <testcase name="doc::doc_deps" time="0" />
-    <testcase name="doc::doc_message_format" time="0" />
-    <testcase name="doc::doc_lib_bin_same_name_documents_lib" time="0" />
-    <testcase name="doc::doc_lib_bin_same_name_documents_lib_when_requested" time="0" />
-    <testcase name="doc::doc_multiple_targets_same_name_bin" time="0" />
-    <testcase name="doc::doc_multiple_targets_same_name_lib" time="0" />
-    <testcase name="doc::doc_lib_bin_same_name_documents_named_bin_when_requested" time="0" />
-    <testcase name="doc::doc_multiple_deps" time="0" />
-    <testcase name="doc::doc_no_libs" time="0" />
-    <testcase name="doc::doc_multiple_targets_same_name" time="0" />
-    <testcase name="doc::doc_multiple_targets_same_name_undoced" time="0" />
-    <testcase name="doc::doc_no_deps" time="0" />
-    <testcase name="doc::doc_private_items" time="0" />
-    <testcase name="doc::doc_private_ws" time="0" />
-    <testcase name="doc::doc_release" time="0" />
-    <testcase name="doc::doc_target_edition" time="0" />
-    <testcase name="doc::doc_target" time="0" />
-    <testcase name="doc::doc_only_bin" time="0" />
-    <testcase name="doc::doc_same_name" time="0" />
-    <testcase name="doc::doc_twice" time="0" />
-    <testcase name="doc::doc_virtual_manifest_all_implied" time="0" />
-    <testcase name="doc::doc_workspace_open_help_message" time="0" />
-    <testcase name="doc::document_only_lib" time="0" />
-    <testcase name="doc::no_document_build_deps" time="0" />
-    <testcase name="doc::plugins_no_use_target" time="0" />
-    <testcase name="doc::features" time="0" />
-    <testcase name="doc::short_message_format" time="0" />
-    <testcase name="doc::issue_5345" time="0" />
-    <testcase name="doc::output_not_captured" time="0" />
-    <testcase name="doc::rerun_when_dir_removed" time="0" />
-    <testcase name="edition::edition_works_for_build_script" time="0" />
-    <testcase name="doc::simple" time="0" />
-    <testcase name="features::activating_feature_activates_dep" time="0" />
-    <testcase name="doc::target_specific_not_documented" time="0" />
-    <testcase name="features::all_features_all_crates" time="0" />
-    <testcase name="features::cyclic_feature" time="0" />
-    <testcase name="features::all_features_flag_enables_all_features" time="0" />
-    <testcase name="features::cyclic_feature2" time="0" />
-    <testcase name="doc::target_specific_documented" time="0" />
-    <testcase name="features::combining_features_and_package" time="0" />
-    <testcase name="features::everything_in_the_lockfile" time="0" />
-    <testcase name="features::empty_features" time="0" />
-    <testcase name="features::default_feature_pulled_in" time="0" />
-    <testcase name="features::invalid1" time="0" />
-    <testcase name="features::dep_feature_in_cmd_line" time="0" />
-    <testcase name="features::invalid2" time="0" />
-    <testcase name="features::invalid3" time="0" />
-    <testcase name="features::groups_on_groups_on_groups" time="0" />
-    <testcase name="features::invalid4" time="0" />
-    <testcase name="features::invalid5" time="0" />
-    <testcase name="features::invalid6" time="0" />
-    <testcase name="features::invalid7" time="0" />
-    <testcase name="features::invalid8" time="0" />
-    <testcase name="features::invalid10" time="0" />
-    <testcase name="features::feature_off_dylib" time="0" />
-    <testcase name="features::invalid9" time="0" />
-    <testcase name="features::many_cli_features" time="0" />
-    <testcase name="features::many_cli_features_comma_and_space_delimited" time="0" />
-    <testcase name="features::namespaced_implicit_non_optional" time="0" />
-    <testcase name="features::many_cli_features_comma_delimited" time="0" />
-    <testcase name="features::namespaced_invalid_dependency" time="0" />
-    <testcase name="features::namespaced_invalid_feature" time="0" />
-    <testcase name="features::namespaced_non_optional_dependency" time="0" />
-    <testcase name="features::namespaced_shadowed_dep" time="0" />
-    <testcase name="features::namespaced_shadowed_non_optional" time="0" />
-    <testcase name="features::namespaced_implicit_feature" time="0" />
-    <testcase name="features::many_features_no_rebuilds" time="0" />
-    <testcase name="features::no_transitive_dep_feature_requirement" time="0" />
-    <testcase name="features::namespaced_same_name" time="0" />
-    <testcase name="features::optional_and_dev_dep" time="0" />
-    <testcase name="features::no_rebuild_when_frobbing_default_feature" time="0" />
-    <testcase name="features::no_feature_doesnt_build" time="0" />
-    <testcase name="features::only_dep_is_optional" time="0" />
-    <testcase name="features::transitive_features" time="0" />
-    <testcase name="fetch::fetch_all_platform_dependencies_when_no_target_is_given" time="0" />
-    <testcase name="fetch::fetch_platform_specific_dependencies" time="0" />
-    <testcase name="fetch::no_deps" time="0" />
-    <testcase name="features::union_features" time="0" />
-    <testcase name="fix::both_edition_migrate_flags" time="0" />
-    <testcase name="features::unions_work_with_no_default_features" time="0" />
-    <testcase name="features::warn_if_default_features" time="0" />
-    <testcase name="fix::does_not_crash_with_rustc_wrapper" time="0" />
-    <testcase name="fix::do_not_fix_non_relevant_deps" time="0" />
-    <testcase name="fix::do_not_fix_broken_builds" time="0" />
-    <testcase name="fix::does_not_warn_about_clean_working_directory" time="0" />
-    <testcase name="fix::does_not_warn_about_dirty_ignored_files" time="0" />
-    <testcase name="fix::fix_all_targets_by_default" time="0" />
-    <testcase name="fix::doesnt_rebuild_dependencies" time="0" />
-    <testcase name="fix::broken_fixes_backed_out" time="0" />
-    <testcase name="fix::fix_broken_if_requested" time="0" />
-    <testcase name="fix::fix_deny_warnings" time="0" />
-    <testcase name="fix::fix_idioms" time="0" />
-    <testcase name="fix::fix_overlapping" time="0" />
-    <testcase name="fix::fix_to_broken_code" time="0" />
-    <testcase name="fix::fix_deny_warnings_but_not_others" time="0" />
-    <testcase name="fix::fix_two_files" time="0" />
-    <testcase name="fix::fix_path_deps" time="0" />
-    <testcase name="fix::fix_with_common" time="0" />
-    <testcase name="fix::fix_features" time="0" />
-    <testcase name="fix::fixes_extra_mut" time="0" />
-    <testcase name="fix::local_paths" time="0" />
-    <testcase name="fix::fixes_two_missing_ampersands" time="0" />
-    <testcase name="fix::idioms_2015_ok" time="0" />
-    <testcase name="fix::prepare_for_2018" time="0" />
-    <testcase name="fix::no_changes_necessary" time="0" />
-    <testcase name="fix::prepare_for_and_enable" time="0" />
-    <testcase name="fix::only_warn_for_relevant_crates" time="0" />
-    <testcase name="fix::preserve_line_endings" time="0" />
-    <testcase name="fix::shows_warnings" time="0" />
-    <testcase name="fix::specify_rustflags" time="0" />
-    <testcase name="fix::shows_warnings_on_second_run_without_changes" time="0" />
-    <testcase name="fix::tricky" time="0" />
-    <testcase name="fix::upgrade_extern_crate" time="0" />
-    <testcase name="fix::warns_about_dirty_working_directory" time="0" />
-    <testcase name="fix::fixes_missing_ampersand" time="0" />
-    <testcase name="fix::warns_about_staged_working_directory" time="0" />
-    <testcase name="fix::shows_warnings_on_second_run_without_changes_on_multiple_targets" time="0" />
-    <testcase name="fix::warns_if_no_vcs_detected" time="0" />
-    <testcase name="freshness::change_panic_mode" time="0" />
-    <testcase name="freshness::bust_patched_dep" time="0" />
-    <testcase name="freshness::changing_bin_features_caches_targets" time="0" />
-    <testcase name="freshness::changing_lib_features_caches_targets" time="0" />
-    <testcase name="freshness::changing_rustflags_is_cached" time="0" />
-    <testcase name="freshness::changing_profiles_caches_targets" time="0" />
-    <testcase name="freshness::dont_rebuild_based_on_plugins" time="0" />
-    <testcase name="freshness::fingerprint_cleaner_does_not_rebuild" time="0" />
-    <testcase name="freshness::modifying_and_moving" time="0" />
-    <testcase name="freshness::no_rebuild_if_build_artifacts_move_backwards_in_time" time="0" />
-    <testcase name="freshness::changing_bin_paths_common_target_features_caches_targets" time="0" />
-    <testcase name="freshness::no_rebuild_when_rename_dir" time="0" />
-    <testcase name="freshness::modify_only_some_files" time="0" />
-    <testcase name="freshness::no_rebuild_transitive_target_deps" time="0" />
-    <testcase name="freshness::path_dev_dep_registry_updates" time="0" />
-    <testcase name="freshness::rebuild_if_build_artifacts_move_forward_in_time" time="0" />
-    <testcase name="freshness::rebuild_if_environment_changes" time="0" />
-    <testcase name="freshness::rebuild_sub_package_then_while_package" time="0" />
-    <testcase name="freshness::rebuild_on_mid_build_file_modification" time="0" />
-    <testcase name="freshness::rerun_if_changed_in_dep" time="0" />
-    <testcase name="freshness::reuse_panic_build_dep_test" time="0" />
-    <testcase name="freshness::reuse_panic_pm" time="0" />
-    <testcase name="freshness::reuse_shared_build_dep" time="0" />
-    <testcase name="freshness::rebuild_tests_if_lib_changes" time="0" />
-    <testcase name="freshness::reuse_workspace_lib" time="0" />
-    <testcase name="freshness::same_build_dir_cached_packages" time="0" />
-    <testcase name="generate_lockfile::adding_and_removing_packages" time="0" />
-    <testcase name="generate_lockfile::cargo_update_generate_lockfile" time="0" />
-    <testcase name="generate_lockfile::duplicate_entries_in_lockfile" time="0" />
-    <testcase name="generate_lockfile::preserve_line_endings_issue_2076" time="0" />
-    <testcase name="freshness::unused_optional_dep" time="0" />
-    <testcase name="generate_lockfile::no_index_update" time="0" />
-    <testcase name="git::cargo_compile_forbird_git_httpsrepo_offline" time="0" />
-    <testcase name="freshness::simple_deps_cleaner_does_not_rebuild" time="0" />
-    <testcase name="generate_lockfile::preserve_metadata" time="0" />
-    <testcase name="git::add_a_git_dep" time="0" />
-    <testcase name="git::cargo_compile_git_dep_branch" time="0" />
-    <testcase name="git::cargo_compile_git_dep_tag" time="0" />
-    <testcase name="git::cargo_compile_simple_git_dep" time="0" />
-    <testcase name="git::cargo_compile_with_malformed_nested_paths" time="0" />
-    <testcase name="git::cargo_compile_with_meta_package" time="0" />
-    <testcase name="git::cargo_compile_with_short_ssh_git" time="0" />
-    <testcase name="git::dep_with_bad_submodule" time="0" />
-    <testcase name="git::denied_lints_are_allowed" time="0" />
-    <testcase name="git::cargo_compile_with_nested_paths" time="0" />
-    <testcase name="git::cargo_compile_offline_with_cached_git_dep" time="0" />
-    <testcase name="git::dep_with_submodule" time="0" />
-    <testcase name="git::dev_deps_with_testing" time="0" />
-    <testcase name="git::doctest_same_name" time="0" />
-    <testcase name="git::dont_require_submodules_are_checked_out" time="0" />
-    <testcase name="git::failed_submodule_checkout" time="0" />
-    <testcase name="git::fetch_downloads" time="0" />
-    <testcase name="git::dep_with_changed_submodule" time="0" />
-    <testcase name="git::git_name_not_always_needed" time="0" />
-    <testcase name="git::invalid_git_dependency_manifest" time="0" />
-    <testcase name="git::git_build_cmd_freshness" time="0" />
-    <testcase name="git::git_dep_build_cmd" time="0" />
-    <testcase name="git::lints_are_suppressed" time="0" />
-    <testcase name="git::git_repo_changing_no_rebuild" time="0" />
-    <testcase name="git::switch_deps_does_not_update_transitive" time="0" />
-    <testcase name="git::stale_cached_version" time="0" />
-    <testcase name="git::recompilation" time="0" />
-    <testcase name="git::switch_sources" time="0" />
-    <testcase name="git::templatedir_doesnt_cause_problems" time="0" />
-    <testcase name="git::two_at_rev_instead_of_tag" time="0" />
-    <testcase name="git::update_one_dep_in_repo_with_many_deps" time="0" />
-    <testcase name="git::two_deps_only_update_one" time="0" />
-    <testcase name="git::two_revs_same_deps" time="0" />
-    <testcase name="git::update_ambiguous" time="0" />
-    <testcase name="git::update_one_source_updates_all_packages_in_that_git_source" time="0" />
-    <testcase name="git::warnings_in_git_dep" time="0" />
-    <testcase name="init::bin_already_exists_explicit" time="0" />
-    <testcase name="init::auto_git" time="0" />
-    <testcase name="init::bin_already_exists_explicit_nosrc" time="0" />
-    <testcase name="init::bin_already_exists_implicit" time="0" />
-    <testcase name="init::bin_already_exists_implicit_namenosrc" time="0" />
-    <testcase name="init::bin_already_exists_implicit_namesrc" time="0" />
-    <testcase name="init::both_lib_and_bin" time="0" />
-    <testcase name="init::bin_already_exists_implicit_nosrc" time="0" />
-    <testcase name="git::use_the_cli" time="0" />
-    <testcase name="init::cargo_lock_gitignored_if_lib1" time="0" />
-    <testcase name="init::cargo_lock_gitignored_if_lib2" time="0" />
-    <testcase name="init::cargo_lock_not_gitignored_if_bin1" time="0" />
-    <testcase name="init::confused_by_multiple_lib_files" time="0" />
-    <testcase name="init::cargo_lock_not_gitignored_if_bin2" time="0" />
-    <testcase name="init::git_autodetect" time="0" />
-    <testcase name="init::gitignore_added_newline_in_existing" time="0" />
-    <testcase name="init::gitignore_appended_not_replaced" time="0" />
-    <testcase name="init::gitignore_no_newline_in_new" time="0" />
-    <testcase name="init::invalid_dir_name" time="0" />
-    <testcase name="init::lib_already_exists_nosrc" time="0" />
-    <testcase name="init::lib_already_exists_src" time="0" />
-    <testcase name="init::mercurial_added_newline_in_existing" time="0" />
-    <testcase name="init::mercurial_autodetect" time="0" />
-    <testcase name="init::mercurial_no_newline_in_new" time="0" />
-    <testcase name="init::reserved_name" time="0" />
-    <testcase name="init::multibin_project_name_clash" time="0" />
-    <testcase name="init::simple_git" time="0" />
-    <testcase name="init::simple_git_ignore_exists" time="0" />
-    <testcase name="init::unknown_flags" time="0" />
-    <testcase name="init::with_argument" time="0" />
-    <testcase name="init::simple_lib" time="0" />
-    <testcase name="init::simple_bin" time="0" />
-    <testcase name="install::bad_paths" time="0" />
-    <testcase name="install::bad_version" time="0" />
-    <testcase name="git::update_with_shared_deps" time="0" />
-    <testcase name="install::compile_failure" time="0" />
-    <testcase name="install::do_not_rebuilds_on_local_install" time="0" />
-    <testcase name="install::dev_dependencies_no_check" time="0" />
-    <testcase name="install::dev_dependencies_lock_file_untouched" time="0" />
-    <testcase name="install::custom_target_dir_for_git_source" time="0" />
-    <testcase name="install::examples" time="0" />
-    <testcase name="install::install_empty_argument" time="0" />
-    <testcase name="install::git_repo" time="0" />
-    <testcase name="install::git_with_lockfile" time="0" />
-    <testcase name="install::git_repo_replace" time="0" />
-    <testcase name="install::install_force" time="0" />
-    <testcase name="install::install_force_bin" time="0" />
-    <testcase name="install::install_global_cargo_config" time="0" />
-    <testcase name="install::install_force_partial_overlap" time="0" />
-    <testcase name="install::install_ignores_local_cargo_config" time="0" />
-    <testcase name="install::install_target_foreign" time="0" />
-    <testcase name="install::install_path" time="0" />
-    <testcase name="install::install_twice" time="0" />
-    <testcase name="install::install_respects_lock_file" time="0" />
-    <testcase name="install::install_target_native" time="0" />
-    <testcase name="install::installs_from_cwd_with_2018_warnings" time="0" />
-    <testcase name="install::installs_from_cwd_by_default" time="0" />
-    <testcase name="install::installs_beta_version_by_explicit_name_from_git" time="0" />
-    <testcase name="install::legacy_version_requirement" time="0" />
-    <testcase name="install::install_location_precedence" time="0" />
-    <testcase name="install::missing" time="0" />
-    <testcase name="install::list_error" time="0" />
-    <testcase name="install::lock_file_path_deps_ok" time="0" />
-    <testcase name="install::multiple_crates_auto_binaries" time="0" />
-    <testcase name="install::multiple_crates_error" time="0" />
-    <testcase name="install::list" time="0" />
-    <testcase name="install::multiple_crates_auto_examples" time="0" />
-    <testcase name="install::no_binaries" time="0" />
-    <testcase name="install::no_binaries_or_examples" time="0" />
-    <testcase name="install::not_both_vers_and_version" time="0" />
-    <testcase name="install::multiple_crates_git_all" time="0" />
-    <testcase name="install::multiple_crates_select" time="0" />
-    <testcase name="install::pick_max_version" time="0" />
-    <testcase name="install::multiple_pkgs" time="0" />
-    <testcase name="install::q_silences_warnings" time="0" />
-    <testcase name="install::readonly_dir" time="0" />
-    <testcase name="install::test_install_git_cannot_be_a_base_url" time="0" />
-    <testcase name="install::simple" time="0" />
-    <testcase name="install::reports_unsuccessful_subcommand_result" time="0" />
-    <testcase name="install::uninstall_cwd_no_project" time="0" />
-    <testcase name="install::uninstall_cwd_not_installed" time="0" />
-    <testcase name="install::subcommand_works_out_of_the_box" time="0" />
-    <testcase name="install::uninstall_multiple_and_specifying_bin" time="0" />
-    <testcase name="install::uninstall_cwd" time="0" />
-    <testcase name="install::uninstall_pkg_does_not_exist" time="0" />
-    <testcase name="install::uninstall_bin_does_not_exist" time="0" />
-    <testcase name="install::uninstall_piecemeal" time="0" />
-    <testcase name="install::uninstall_multiple_and_some_pkg_does_not_exist" time="0" />
-    <testcase name="install::vers_precise" time="0" />
-    <testcase name="jobserver::jobserver_and_j" time="0" />
-    <testcase name="install::use_path_workspace" time="0" />
-    <testcase name="jobserver::makes_jobserver_used" time="0" />
-    <testcase name="install::workspace_uses_workspace_target_dir" time="0" />
-    <testcase name="install::version_too" time="0" />
-    <testcase name="list_targets::bench_list_targets" time="0" />
-    <testcase name="list_targets::build_list_targets" time="0" />
-    <testcase name="list_targets::doc_list_targets" time="0" />
-    <testcase name="list_targets::check_list_targets" time="0" />
-    <testcase name="list_targets::install_list_targets" time="0" />
-    <testcase name="list_targets::run_list_targets" time="0" />
-    <testcase name="jobserver::jobserver_exists" time="0" />
-    <testcase name="list_targets::fix_list_targets" time="0" />
-    <testcase name="list_targets::rustc_list_targets" time="0" />
-    <testcase name="list_targets::rustdoc_list_targets" time="0" />
-    <testcase name="list_targets::test_list_targets" time="0" />
-    <testcase name="local_registry::invalid_dir_bad" time="0" />
-    <testcase name="local_registry::different_directory_replacing_the_registry_is_bad" time="0" />
-    <testcase name="local_registry::interdependent" time="0" />
-    <testcase name="local_registry::multiple_names" time="0" />
-    <testcase name="local_registry::crates_io_registry_url_is_optional" time="0" />
-    <testcase name="local_registry::multiple_versions" time="0" />
-    <testcase name="local_registry::path_dep_rewritten" time="0" />
-    <testcase name="lockfile_compat::current_lockfile_format" time="0" />
-    <testcase name="lockfile_compat::listed_checksum_bad_if_we_cannot_compute" time="0" />
-    <testcase name="lockfile_compat::locked_correct_error" time="0" />
-    <testcase name="local_registry::simple" time="0" />
-    <testcase name="lockfile_compat::frozen_flag_preserves_old_lockfile" time="0" />
-    <testcase name="lockfile_compat::unlisted_checksum_is_bad_if_we_calculate" time="0" />
-    <testcase name="lockfile_compat::lockfile_without_root" time="0" />
-    <testcase name="lockfile_compat::totally_wild_checksums_works" time="0" />
-    <testcase name="lockfile_compat::wrong_checksum_is_an_error" time="0" />
-    <testcase name="login::login_with_new_credentials" time="0" />
-    <testcase name="lockfile_compat::oldest_lockfile_still_works" time="0" />
-    <testcase name="login::login_with_old_and_new_credentials" time="0" />
-    <testcase name="login::new_credentials_is_used_instead_old" time="0" />
-    <testcase name="login::login_with_old_credentials" time="0" />
-    <testcase name="login::login_without_credentials" time="0" />
-    <testcase name="member_errors::toml_deserialize_manifest_error" time="0" />
-    <testcase name="member_errors::member_manifest_path_io_error" time="0" />
-    <testcase name="login::registry_credentials" time="0" />
-    <testcase name="metabuild::metabuild_error_both" time="0" />
-    <testcase name="metabuild::metabuild_build_plan" time="0" />
-    <testcase name="metabuild::metabuild_basic" time="0" />
-    <testcase name="member_errors::member_manifest_version_error" time="0" />
-    <testcase name="metabuild::metabuild_gated" time="0" />
-    <testcase name="metabuild::metabuild_failed_build_json" time="0" />
-    <testcase name="metabuild::metabuild_external_dependency" time="0" />
-    <testcase name="metabuild::metabuild_fresh" time="0" />
-    <testcase name="metabuild::metabuild_lib_name" time="0" />
-    <testcase name="metabuild::metabuild_json_artifact" time="0" />
-    <testcase name="metabuild::metabuild_metadata" time="0" />
-    <testcase name="metabuild::metabuild_missing_dep" time="0" />
-    <testcase name="metabuild::metabuild_override" time="0" />
-    <testcase name="metabuild::metabuild_links" time="0" />
-    <testcase name="metadata::cargo_metadata_bad_version" time="0" />
-    <testcase name="metadata::cargo_metadata_no_deps_cwd" time="0" />
-    <testcase name="metadata::cargo_metadata_no_deps_path_to_cargo_toml_absolute" time="0" />
-    <testcase name="metadata::cargo_metadata_no_deps_path_to_cargo_toml_parent_absolute" time="0" />
-    <testcase name="metadata::cargo_metadata_no_deps_path_to_cargo_toml_parent_relative" time="0" />
-    <testcase name="metabuild::metabuild_two_versions" time="0" />
-    <testcase name="metadata::cargo_metadata_no_deps_path_to_cargo_toml_relative" time="0" />
-    <testcase name="metadata::cargo_metadata_simple" time="0" />
-    <testcase name="metadata::cargo_metadata_warns_on_implicit_version" time="0" />
-    <testcase name="metabuild::metabuild_optional_dep" time="0" />
-    <testcase name="metadata::cargo_metadata_with_invalid_manifest" time="0" />
-    <testcase name="metabuild::metabuild_workspace" time="0" />
-    <testcase name="metadata::example" time="0" />
-    <testcase name="metadata::cargo_metadata_path_to_cargo_toml_project" time="0" />
-    <testcase name="metadata::example_lib" time="0" />
-    <testcase name="metadata::library_with_features" time="0" />
-    <testcase name="metadata::library_with_several_crate_types" time="0" />
-    <testcase name="metadata::multiple_features" time="0" />
-    <testcase name="metadata::metadata_links" time="0" />
-    <testcase name="metadata::package_edition_2018" time="0" />
-    <testcase name="metadata::package_metadata" time="0" />
-    <testcase name="metadata::target_edition_2018" time="0" />
-    <testcase name="metadata::workspace_metadata" time="0" />
-    <testcase name="metadata::cargo_metadata_with_deps_and_version" time="0" />
-    <testcase name="metadata::workspace_metadata_no_deps" time="0" />
-    <testcase name="new::author_prefers_cargo" time="0" />
-    <testcase name="new::both_lib_and_bin" time="0" />
-    <testcase name="metadata::rename_dependency" time="0" />
-    <testcase name="new::existing" time="0" />
-    <testcase name="new::explicit_invalid_name_not_suggested" time="0" />
-    <testcase name="new::explicit_project_name" time="0" />
-    <testcase name="new::finds_author_email" time="0" />
-    <testcase name="new::finds_author_priority" time="0" />
-    <testcase name="new::finds_author_git" time="0" />
-    <testcase name="new::finds_author_user" time="0" />
-    <testcase name="new::finds_author_user_escaped" time="0" />
-    <testcase name="new::finds_author_username" time="0" />
-    <testcase name="new::finds_git_author" time="0" />
-    <testcase name="new::finds_git_email" time="0" />
-    <testcase name="new::git_prefers_command_line" time="0" />
-    <testcase name="new::invalid_characters" time="0" />
-    <testcase name="new::keyword_name" time="0" />
-    <testcase name="new::new_default_edition" time="0" />
-    <testcase name="new::new_with_bad_edition" time="0" />
-    <testcase name="new::new_with_edition_2015" time="0" />
-    <testcase name="new::finds_local_author_git" time="0" />
-    <testcase name="new::no_argument" time="0" />
-    <testcase name="new::new_with_edition_2018" time="0" />
-    <testcase name="new::reserved_binary_name" time="0" />
-    <testcase name="new::reserved_name" time="0" />
-    <testcase name="net_config::net_retry_loads_from_config" time="0" />
-    <testcase name="new::simple_git" time="0" />
-    <testcase name="new::strip_angle_bracket_author_email" time="0" />
-    <testcase name="new::simple_lib" time="0" />
-    <testcase name="new::simple_bin" time="0" />
-    <testcase name="net_config::net_retry_git_outputs_warning" time="0" />
-    <testcase name="new::subpackage_git_with_gitignore" time="0" />
-    <testcase name="new::subpackage_git_with_vcs_arg" time="0" />
-    <testcase name="new::unknown_flags" time="0" />
-    <testcase name="new::subpackage_no_git" time="0" />
-    <testcase name="out_dir::binary_with_debug" time="0" />
-    <testcase name="out_dir::dynamic_library_with_debug" time="0" />
-    <testcase name="out_dir::include_only_the_binary_from_the_current_package" time="0" />
-    <testcase name="out_dir::avoid_build_scripts" time="0" />
-    <testcase name="out_dir::out_dir_is_a_file" time="0" />
-    <testcase name="out_dir::rlib_with_debug" time="0" />
-    <testcase name="out_dir::static_library_with_debug" time="0" />
-    <testcase name="overrides::invalid_semver_version" time="0" />
-    <testcase name="overrides::different_version" time="0" />
-    <testcase name="overrides::missing_version" time="0" />
-    <testcase name="overrides::broken_path_override_warns" time="0" />
-    <testcase name="overrides::multiple_specs" time="0" />
-    <testcase name="out_dir::replaces_artifacts" time="0" />
-    <testcase name="overrides::locked_means_locked_yes_no_seriously_i_mean_locked" time="0" />
-    <testcase name="overrides::no_override_self" time="0" />
-    <testcase name="overrides::no_warnings_when_replace_is_used_in_another_workspace_member" time="0" />
-    <testcase name="overrides::override_plus_dep" time="0" />
-    <testcase name="overrides::override_adds_some_deps" time="0" />
-    <testcase name="overrides::override_an_override" time="0" />
-    <testcase name="overrides::override_simple" time="0" />
-    <testcase name="overrides::override_to_path_dep" time="0" />
-    <testcase name="overrides::override_wrong_version" time="0" />
-    <testcase name="overrides::override_with_nothing" time="0" />
-    <testcase name="overrides::override_wrong_name" time="0" />
-    <testcase name="overrides::paths_ok_with_optional" time="0" />
-    <testcase name="overrides::paths_add_optional_bad" time="0" />
-    <testcase name="overrides::overriding_nonexistent_no_spurious" time="0" />
-    <testcase name="overrides::override_with_default_feature" time="0" />
-    <testcase name="overrides::replace_registry_with_path" time="0" />
-    <testcase name="overrides::test_override_dep" time="0" />
-    <testcase name="overrides::persists_across_rebuilds" time="0" />
-    <testcase name="overrides::replace_to_path_dep" time="0" />
-    <testcase name="package::do_not_package_if_repository_is_dirty" time="0" />
-    <testcase name="overrides::update" time="0" />
-    <testcase name="package::edition_with_metadata" time="0" />
-    <testcase name="overrides::transitive" time="0" />
-    <testcase name="package::exclude" time="0" />
-    <testcase name="overrides::use_a_spec_to_select" time="0" />
-    <testcase name="package::ignore_workspace_specifier" time="0" />
-    <testcase name="package::do_not_package_if_src_was_modified" time="0" />
-    <testcase name="package::include" time="0" />
-    <testcase name="package::generated_manifest" time="0" />
-    <testcase name="package::lock_file_and_workspace" time="0" />
-    <testcase name="package::ignore_nested" time="0" />
-    <testcase name="package::no_duplicates_from_modified_tracked_files" time="0" />
-    <testcase name="package::no_lock_file_with_library" time="0" />
-    <testcase name="package::package_git_submodule" time="0" />
-    <testcase name="package::package_lockfile_git_repo" time="0" />
-    <testcase name="package::package_lib_with_bin" time="0" />
-    <testcase name="package::metadata_warning" time="0" />
-    <testcase name="package::package_no_default_features" time="0" />
-    <testcase name="package::package_two_kinds_of_deps" time="0" />
-    <testcase name="package::package_lockfile" time="0" />
-    <testcase name="package::package_with_all_features" time="0" />
-    <testcase name="package::package_verbose" time="0" />
-    <testcase name="package::path_dependency_no_version" time="0" />
-    <testcase name="package::package_with_select_features" time="0" />
-    <testcase name="package::package_verification" time="0" />
-    <testcase name="package::test_edition_malformed" time="0" />
-    <testcase name="package::test_edition" time="0" />
-    <testcase name="package::vcs_file_collision" time="0" />
-    <testcase name="package::repackage_on_source_change" time="0" />
-    <testcase name="package::simple" time="0" />
-    <testcase name="patch::add_patch" time="0" />
-    <testcase name="patch::add_ignored_patch" time="0" />
-    <testcase name="patch::new_minor" time="0" />
-    <testcase name="patch::non_crates_io" time="0" />
-    <testcase name="patch::no_warn_ws_patch" time="0" />
-    <testcase name="patch::new_major" time="0" />
-    <testcase name="patch::nonexistent" time="0" />
-    <testcase name="patch::patch_depends_on_another_patch" time="0" />
-    <testcase name="patch::patch_git" time="0" />
-    <testcase name="patch::patch_in_virtual" time="0" />
-    <testcase name="patch::patch_to_git" time="0" />
-    <testcase name="patch::remove_patch" time="0" />
-    <testcase name="patch::replace" time="0" />
-    <testcase name="patch::replace_prerelease" time="0" />
-    <testcase name="patch::replace_with_crates_io" time="0" />
-    <testcase name="patch::transitive_new_major" time="0" />
-    <testcase name="patch::transitive_new_minor" time="0" />
-    <testcase name="patch::unused" time="0" />
-    <testcase name="path::cargo_compile_with_root_dev_deps" time="0" />
-    <testcase name="patch::unused_git" time="0" />
-    <testcase name="path::cargo_compile_with_root_dev_deps_with_testing" time="0" />
-    <testcase name="path::cargo_compile_with_transitive_dev_deps" time="0" />
-    <testcase name="path::error_message_for_missing_manifest" time="0" />
-    <testcase name="path::custom_target_no_rebuild" time="0" />
-    <testcase name="path::missing_path_dependency" time="0" />
-    <testcase name="path::dev_deps_no_rebuild_lib" time="0" />
-    <testcase name="path::invalid_path_dep_in_workspace_with_lockfile" time="0" />
-    <testcase name="path::nested_deps_recompile" time="0" />
-    <testcase name="path::no_rebuild_two_deps" time="0" />
-    <testcase name="path::override_path_dep" time="0" />
-    <testcase name="path::override_and_depend" time="0" />
-    <testcase name="path::no_rebuild_dependency" time="0" />
-    <testcase name="path::override_relative" time="0" />
-    <testcase name="path::override_self" time="0" />
-    <testcase name="path::workspace_produces_rlib" time="0" />
-    <testcase name="path::deep_dependencies_trigger_rebuild" time="0" />
-    <testcase name="path::path_dep_build_cmd" time="0" />
-    <testcase name="plugins::panic_abort_plugins" time="0" />
-    <testcase name="plugins::native_plugin_dependency_with_custom_ar_linker" time="0" />
-    <testcase name="plugins::plugin_to_the_max" time="0" />
-    <testcase name="plugins::plugin_with_dynamic_native_dependency" time="0" />
-    <testcase name="plugins::shared_panic_abort_plugins" time="0" />
-    <testcase name="plugins::doctest_a_plugin" time="0" />
-    <testcase name="plugins::plugin_integration" time="0" />
-    <testcase name="proc_macro::plugin_and_proc_macro" time="0" />
-    <testcase name="path::thin_lto_works" time="0" />
-    <testcase name="proc_macro::noop" time="0" />
-    <testcase name="proc_macro::proc_macro_crate_type_multiple" time="0" />
-    <testcase name="proc_macro::impl_and_derive" time="0" />
-    <testcase name="proc_macro::proc_macro_crate_type_warning" time="0" />
-    <testcase name="proc_macro::probe_cfg_before_crate_type_discovery" time="0" />
-    <testcase name="proc_macro::proc_macro_crate_type_warning_plugin" time="0" />
-    <testcase name="profile_config::profile_config_error_paths" time="0" />
-    <testcase name="profile_config::profile_config_all_options" time="0" />
-    <testcase name="profile_config::profile_config_gated" time="0" />
-    <testcase name="profile_config::profile_config_mixed_types" time="0" />
-    <testcase name="profile_config::profile_config_no_warn_unknown_override" time="0" />
-    <testcase name="profile_config::profile_config_override_spec_multiple" time="0" />
-    <testcase name="profile_config::profile_config_syntax_errors" time="0" />
-    <testcase name="profile_config::profile_config_validate_errors" time="0" />
-    <testcase name="profile_config::profile_config_override_precedence" time="0" />
-    <testcase name="proc_macro::proc_macro_doctest" time="0" />
-    <testcase name="profile_config::profile_config_validate_warnings" time="0" />
-    <testcase name="proc_macro::proc_macro_crate_type" time="0" />
-    <testcase name="profile_overrides::profile_override_dev_release_only" time="0" />
-    <testcase name="profile_overrides::profile_override_bad_settings" time="0" />
-    <testcase name="profile_overrides::profile_override_gated" time="0" />
-    <testcase name="profile_overrides::profile_override_spec_multiple" time="0" />
-    <testcase name="profile_overrides::profile_override_basic" time="0" />
-    <testcase name="profile_overrides::profile_override_spec" time="0" />
-    <testcase name="profile_overrides::profile_override_warnings" time="0" />
-    <testcase name="profile_overrides::profile_override_hierarchy" time="0" />
-    <testcase name="profile_targets::profile_selection_build" time="0" />
-    <testcase name="profile_targets::profile_selection_build_all_targets" time="0" />
-    <testcase name="profile_targets::profile_selection_check_all_targets" time="0" />
-    <testcase name="profile_targets::profile_selection_check_all_targets_release" time="0" />
-    <testcase name="profile_targets::profile_selection_bench" time="0" />
-    <testcase name="profile_targets::profile_selection_check_all_targets_test" time="0" />
-    <testcase name="profile_targets::profile_selection_build_all_targets_release" time="0" />
-    <testcase name="profile_targets::profile_selection_build_release" time="0" />
-    <testcase name="profiles::debug_override_1" time="0" />
-    <testcase name="profiles::opt_level_override_0" time="0" />
-    <testcase name="profiles::opt_level_overrides" time="0" />
-    <testcase name="profiles::profile_doc_deprecated" time="0" />
-    <testcase name="profile_targets::profile_selection_test" time="0" />
-    <testcase name="profile_targets::profile_selection_test_release" time="0" />
-    <testcase name="profiles::profile_in_non_root_manifest_triggers_a_warning" time="0" />
-    <testcase name="profiles::profile_in_virtual_manifest_works" time="0" />
-    <testcase name="profiles::profile_overrides" time="0" />
-    <testcase name="profiles::profile_panic_test_bench" time="0" />
-    <testcase name="publish::block_publish_feature_not_enabled" time="0" />
-    <testcase name="profile_targets::profile_selection_doc" time="0" />
-    <testcase name="publish::block_publish_no_registry" time="0" />
-    <testcase name="profiles::top_level_overrides_deps" time="0" />
-    <testcase name="publish::dont_publish_dirty" time="0" />
-    <testcase name="publish::git_deps" time="0" />
-    <testcase name="publish::new_crate_rejected" time="0" />
-    <testcase name="publish::old_token_location" time="0" />
-    <testcase name="publish::dry_run" time="0" />
-    <testcase name="publish::ignore_when_crate_ignored" time="0" />
-    <testcase name="publish::path_dependency_no_version" time="0" />
-    <testcase name="publish::publish_empty_list" time="0" />
-    <testcase name="publish::publish_allowed_registry" time="0" />
-    <testcase name="publish::publish_clean" time="0" />
-    <testcase name="publish::publish_in_sub_repo" time="0" />
-    <testcase name="publish::publish_when_ignored" time="0" />
-    <testcase name="publish::publish_with_all_features" time="0" />
-    <testcase name="publish::publish_with_no_default_features" time="0" />
-    <testcase name="publish::registry_not_in_publish_list" time="0" />
-    <testcase name="publish::simple" time="0" />
-    <testcase name="publish::simple_with_host" time="0" />
-    <testcase name="publish::simple_with_index_and_host" time="0" />
-    <testcase name="read_manifest::cargo_read_manifest_cwd" time="0" />
-    <testcase name="publish::publish_with_select_features" time="0" />
-    <testcase name="publish::unpublishable_crate" time="0" />
-    <testcase name="read_manifest::cargo_read_manifest_path_to_cargo_toml_absolute" time="0" />
-    <testcase name="publish::publish_with_patch" time="0" />
-    <testcase name="read_manifest::cargo_read_manifest_path_to_cargo_toml_parent_relative" time="0" />
-    <testcase name="read_manifest::cargo_read_manifest_path_to_cargo_toml_parent_absolute" time="0" />
-    <testcase name="read_manifest::cargo_read_manifest_path_to_cargo_toml_relative" time="0" />
-    <testcase name="registry::bad_cksum" time="0" />
-    <testcase name="registry::bad_and_or_malicious_packages_rejected" time="0" />
-    <testcase name="registry::bad_license_file" time="0" />
-    <testcase name="registry::add_dep_dont_update_registry" time="0" />
-    <testcase name="registry::bundled_crate_in_registry" time="0" />
-    <testcase name="registry::disallow_network" time="0" />
-    <testcase name="registry::bump_version_dont_update_registry" time="0" />
-    <testcase name="registry::deps" time="0" />
-    <testcase name="registry::fetch_downloads" time="0" />
-    <testcase name="registry::dev_dependency_not_used" time="0" />
-    <testcase name="registry::git_and_registry_dep" time="0" />
-    <testcase name="registry::lockfile_locks" time="0" />
-    <testcase name="registry::git_init_templatedir_missing" time="0" />
-    <testcase name="registry::login_with_no_cargo_dir" time="0" />
-    <testcase name="registry::login_with_differently_sized_token" time="0" />
-    <testcase name="registry::mis_hyphenated" time="0" />
-    <testcase name="registry::lockfile_locks_transitively" time="0" />
-    <testcase name="registry::nonexistent" time="0" />
-    <testcase name="registry::old_version_req" time="0" />
-    <testcase name="registry::old_version_req_upstream" time="0" />
-    <testcase name="registry::only_download_relevant" time="0" />
-    <testcase name="registry::package_with_path_deps" time="0" />
-    <testcase name="registry::relying_on_a_yank_is_bad" time="0" />
-    <testcase name="registry::resolve_and_backtracking" time="0" />
-    <testcase name="registry::toml_lies_but_index_is_truth" time="0" />
-    <testcase name="registry::update_backtracking_ok" time="0" />
-    <testcase name="registry::simple" time="0" />
-    <testcase name="registry::update_offline" time="0" />
-    <testcase name="registry::rename_deps_and_features" time="0" />
-    <testcase name="registry::update_registry" time="0" />
-    <testcase name="registry::update_multiple_packages" time="0" />
-    <testcase name="registry::update_same_prefix_oh_my_how_was_this_a_bug" time="0" />
-    <testcase name="registry::update_lockfile" time="0" />
-    <testcase name="registry::update_publish_then_update" time="0" />
-    <testcase name="registry::update_with_lockfile_if_packages_missing" time="0" />
-    <testcase name="registry::update_transitive_dependency" time="0" />
-    <testcase name="registry::upstream_warnings_on_extra_verbose" time="0" />
-    <testcase name="registry::updating_a_dep" time="0" />
-    <testcase name="registry::wrong_case" time="0" />
-    <testcase name="registry::use_semver" time="0" />
-    <testcase name="registry::vv_prints_warnings" time="0" />
-    <testcase name="registry::wrong_version" time="0" />
-    <testcase name="rename_deps::features_not_working" time="0" />
-    <testcase name="registry::yanks_are_not_used" time="0" />
-    <testcase name="registry::yanks_in_lockfiles_are_ok" time="0" />
-    <testcase name="rename_deps::can_run_doc_tests" time="0" />
-    <testcase name="rename_deps::features_still_work" time="0" />
-    <testcase name="rename_deps::rename_and_patch" time="0" />
-    <testcase name="rename_deps::rename_affects_fingerprint" time="0" />
-    <testcase name="rename_deps::lots_of_names" time="0" />
-    <testcase name="rename_deps::rename_dependency" time="0" />
-    <testcase name="required_features::bench_arg_features" time="0" />
-    <testcase name="rename_deps::rename_twice" time="0" />
-    <testcase name="required_features::bench_default_features" time="0" />
-    <testcase name="rename_deps::rename_with_dash" time="0" />
-    <testcase name="required_features::bench_multiple_required_features" time="0" />
-    <testcase name="rename_deps::rename_with_different_names" time="0" />
-    <testcase name="required_features::build_bin_arg_features" time="0" />
-    <testcase name="required_features::build_example_arg_features" time="0" />
-    <testcase name="required_features::build_bin_default_features" time="0" />
-    <testcase name="required_features::build_bin_multiple_required_features" time="0" />
-    <testcase name="required_features::build_example_default_features" time="0" />
-    <testcase name="required_features::install_arg_features" time="0" />
-    <testcase name="required_features::build_example_multiple_required_features" time="0" />
-    <testcase name="required_features::install_multiple_required_features" time="0" />
-    <testcase name="required_features::dep_feature_in_toml" time="0" />
-    <testcase name="required_features::run_default_multiple_required_features" time="0" />
-    <testcase name="required_features::install_default_features" time="0" />
-    <testcase name="required_features::dep_feature_in_cmd_line" time="0" />
-    <testcase name="required_features::run_default" time="0" />
-    <testcase name="required_features::test_arg_features" time="0" />
-    <testcase name="resolve::conflict_store_bug" time="0" />
-    <testcase name="resolve::hard_equality" time="0" />
-    <testcase name="resolve::incomplete_information_skiping" time="0" />
-    <testcase name="resolve::incomplete_information_skiping_2" time="0" />
-    <testcase name="resolve::incomplete_information_skiping_3" time="0" />
-    <testcase name="required_features::test_default_features" time="0" />
-    <testcase name="required_features::test_multiple_required_features" time="0" />
-    <testcase name="required_features::test_skips_compiling_bin_with_missing_required_features" time="0" />
-    <testcase name="resolve::minimal_version_cli" time="0" />
-    <testcase name="resolve::large_conflict_cache" time="0" />
-    <testcase name="resolve::limited_independence_of_irrelevant_alternatives" time="0" />
-    <testcase name="resolve::resolving_allows_multiple_compatible_versions" time="0" />
-    <testcase name="resolve::resolving_backtrack" time="0" />
-    <testcase name="resolve::resolving_backtrack_features" time="0" />
-    <testcase name="resolve::resolving_but_no_exists" time="0" />
-    <testcase name="resolve::resolving_cycle" time="0" />
-    <testcase name="resolve::resolving_incompat_versions" time="0" />
-    <testcase name="resolve::resolving_mis_hyphenated_from_registry" time="0" />
-    <testcase name="resolve::passes_validation" time="0" />
-    <testcase name="resolve::resolving_with_constrained_sibling_backtrack_activation" time="0" />
-    <testcase name="resolve::resolving_with_constrained_sibling_backtrack_parent" time="0" />
-    <testcase name="resolve::resolving_with_constrained_sibling_transitive_dep_effects" time="0" />
-    <testcase name="resolve::resolving_with_deep_backtracking" time="0" />
-    <testcase name="resolve::resolving_with_deep_traps" time="0" />
-    <testcase name="resolve::minimum_version_errors_the_same" time="0" />
-    <testcase name="resolve::resolving_with_many_versions" time="0" />
-    <testcase name="resolve::resolving_with_specific_version" time="0" />
-    <testcase name="resolve::resolving_with_sys_crates" time="0" />
-    <testcase name="resolve::resolving_wrong_case_from_registry" time="0" />
-    <testcase name="resolve::test_dependency_with_empty_name" time="0" />
-    <testcase name="resolve::test_resolving_common_transitive_deps" time="0" />
-    <testcase name="resolve::test_resolving_empty_dependency_list" time="0" />
-    <testcase name="resolve::test_resolving_maximum_version_with_transitive_deps" time="0" />
-    <testcase name="resolve::test_resolving_minimum_version_with_transitive_deps" time="0" />
-    <testcase name="resolve::test_resolving_multiple_deps" time="0" />
-    <testcase name="resolve::test_resolving_one_dep" time="0" />
-    <testcase name="resolve::test_resolving_only_package" time="0" />
-    <testcase name="resolve::test_resolving_transitive_deps" time="0" />
-    <testcase name="resolve::test_resolving_with_dev_deps" time="0" />
-    <testcase name="resolve::test_resolving_with_same_name" time="0" />
-    <testcase name="run::autobins_disables" time="0" />
-    <testcase name="run::bogus_default_run" time="0" />
-    <testcase name="resolve::resolving_with_constrained_cousins_backtrack" time="0" />
-    <testcase name="run::default_run_unstable" time="0" />
-    <testcase name="run::default_run_workspace" time="0" />
-    <testcase name="run::dashes_are_forwarded" time="0" />
-    <testcase name="run::either_name_or_example" time="0" />
-    <testcase name="resolve::removing_a_dep_cant_brake" time="0" />
-    <testcase name="run::exit_code" time="0" />
-    <testcase name="run::exit_code_verbose" time="0" />
-    <testcase name="run::example_with_release_flag" time="0" />
-    <testcase name="run::explicit_bin_with_args" time="0" />
-    <testcase name="run::no_main_file" time="0" />
-    <testcase name="run::fail_no_extra_verbose" time="0" />
-    <testcase name="run::one_bin_multiple_examples" time="0" />
-    <testcase name="run::quiet_and_verbose_config" time="0" />
-    <testcase name="run::library_paths_sorted_alphabetically" time="0" />
-    <testcase name="run::release_works" time="0" />
-    <testcase name="run::run_bins" time="0" />
-    <testcase name="run::run_bin_different_name" time="0" />
-    <testcase name="run::run_bin_example" time="0" />
-    <testcase name="run::run_example_autodiscover_2015" time="0" />
-    <testcase name="run::run_example_autodiscover_2015_with_autoexamples_disabled" time="0" />
-    <testcase name="run::run_example_autodiscover_2015_with_autoexamples_enabled" time="0" />
-    <testcase name="run::run_example_autodiscover_2018" time="0" />
-    <testcase name="run::run_example" time="0" />
-    <testcase name="run::run_library_example" time="0" />
-    <testcase name="run::run_dylib_dep" time="0" />
-    <testcase name="run::run_with_filename" time="0" />
-    <testcase name="run::run_from_executable_folder" time="0" />
-    <testcase name="run::run_workspace" time="0" />
-    <testcase name="run::run_with_library_paths" time="0" />
-    <testcase name="run::run_multiple_packages" time="0" />
-    <testcase name="run::simple_quiet_and_verbose" time="0" />
-    <testcase name="run::simple" time="0" />
-    <testcase name="run::simple_quiet" time="0" />
-    <testcase name="run::simple_with_args" time="0" />
-    <testcase name="run::too_many_bins" time="0" />
-    <testcase name="run::specify_default_run" time="0" />
-    <testcase name="rustc::build_foo_with_bar_dependency" time="0" />
-    <testcase name="run::specify_name" time="0" />
-    <testcase name="rustc::build_lib_for_foo" time="0" />
-    <testcase name="rustc::build_only_bar_dependency" time="0" />
-    <testcase name="rustc::build_main_and_allow_unstable_options" time="0" />
-    <testcase name="rustc::fail_with_multiple_packages" time="0" />
-    <testcase name="rustc::fails_when_trying_to_build_main_and_lib_with_args" time="0" />
-    <testcase name="rustc::fails_with_args_to_all_binaries" time="0" />
-    <testcase name="rustc::build_with_args_to_one_of_multiple_binaries" time="0" />
-    <testcase name="rustc::build_with_args_to_one_of_multiple_tests" time="0" />
-    <testcase name="rustc::lib" time="0" />
-    <testcase name="rustc::rustc_fingerprint" time="0" />
-    <testcase name="rustc::rustc_test_with_implicit_bin" time="0" />
-    <testcase name="rustc::rustc_with_other_profile" time="0" />
-    <testcase name="rustc::targets_selected_all" time="0" />
-    <testcase name="rustc::targets_selected_default" time="0" />
-    <testcase name="rustdoc::features" time="0" />
-    <testcase name="rustdoc::rustdoc_args" time="0" />
-    <testcase name="rustc_info_cache::rustc_info_cache" time="0" />
-    <testcase name="rustdoc::rustdoc_foo_with_bar_dependency" time="0" />
-    <testcase name="rustdoc::rustdoc_only_bar_dependency" time="0" />
-    <testcase name="rustdoc::rustdoc_same_name_documents_lib" time="0" />
-    <testcase name="rustdocflags::bad_flags" time="0" />
-    <testcase name="rustdoc::rustdoc_simple" time="0" />
-    <testcase name="rustdocflags::parses_config" time="0" />
-    <testcase name="rustdocflags::parses_env" time="0" />
-    <testcase name="resolve::resolving_with_many_equivalent_backtracking" time="0" />
-    <testcase name="rustdocflags::rustdocflags_passed_to_rustdoc_through_cargo_test_only_once" time="0" />
-    <testcase name="rustflags::build_rustflags_build_script" time="0" />
-    <testcase name="rustdocflags::rustdocflags_passed_to_rustdoc_through_cargo_test" time="0" />
-    <testcase name="rustflags::build_rustflags_build_script_dep" time="0" />
-    <testcase name="rustflags::build_rustflags_build_script_dep_with_target" time="0" />
-    <testcase name="rustflags::build_rustflags_no_recompile" time="0" />
-    <testcase name="rustflags::build_rustflags_build_script_with_target" time="0" />
-    <testcase name="rustflags::build_rustflags_plugin" time="0" />
-    <testcase name="rustflags::build_rustflags_plugin_dep" time="0" />
-    <testcase name="rustflags::build_rustflags_normal_source" time="0" />
-    <testcase name="rustdocflags::rerun" time="0" />
-    <testcase name="rustflags::build_rustflags_plugin_with_target" time="0" />
-    <testcase name="rustflags::build_rustflags_normal_source_with_target" time="0" />
-    <testcase name="rustflags::build_rustflags_plugin_dep_with_target" time="0" />
-    <testcase name="rustflags::build_rustflags_recompile" time="0" />
-    <testcase name="rustflags::build_rustflags_with_home_config" time="0" />
-    <testcase name="rustflags::build_rustflags_recompile2" time="0" />
-    <testcase name="rustflags::env_rustflags_build_script" time="0" />
-    <testcase name="rustflags::env_rustflags_build_script_dep" time="0" />
-    <testcase name="rustflags::cfg_rustflags_normal_source" time="0" />
-    <testcase name="rustflags::env_rustflags_build_script_dep_with_target" time="0" />
-    <testcase name="rustflags::env_rustflags_build_script_with_target" time="0" />
-    <testcase name="rustflags::cfg_rustflags_precedence" time="0" />
-    <testcase name="rustflags::env_rustflags_no_recompile" time="0" />
-    <testcase name="rustflags::env_rustflags_plugin" time="0" />
-    <testcase name="rustflags::env_rustflags_plugin_dep" time="0" />
-    <testcase name="rustflags::env_rustflags_plugin_dep_with_target" time="0" />
-    <testcase name="rustflags::env_rustflags_normal_source" time="0" />
-    <testcase name="rustflags::env_rustflags_plugin_with_target" time="0" />
-    <testcase name="rustflags::env_rustflags_normal_source_with_target" time="0" />
-    <testcase name="rustflags::env_rustflags_recompile" time="0" />
-    <testcase name="rustflags::env_rustflags_recompile2" time="0" />
-    <testcase name="rustflags::target_rustflags_string_and_array_form1" time="0" />
-    <testcase name="rustflags::target_rustflags_string_and_array_form2" time="0" />
-    <testcase name="search::help" time="0" />
-    <testcase name="rustflags::target_rustflags_normal_source" time="0" />
-    <testcase name="search::multiple_query_params" time="0" />
-    <testcase name="rustflags::target_rustflags_precedence" time="0" />
-    <testcase name="search::not_update" time="0" />
-    <testcase name="search::replace_default" time="0" />
-    <testcase name="rustflags::two_matching_in_config" time="0" />
-    <testcase name="search::simple" time="0" />
-    <testcase name="search::simple_with_index_and_host" time="0" />
-    <testcase name="support::lines_match_works" time="0" />
-    <testcase name="support::resolver::meta_test_deep_pretty_print_registry" time="0" />
-    <testcase name="search::simple_with_host" time="0" />
-    <testcase name="shell_quoting::features_are_quoted" time="0" />
-    <testcase name="test::almost_cyclic_but_not_quite" time="0" />
-    <testcase name="support::resolver::meta_test_deep_trees_from_strategy" time="0" />
-    <testcase name="test::bench_without_name" time="0" />
-    <testcase name="test::bad_example" time="0" />
-    <testcase name="test::bin_is_preserved" time="0" />
-    <testcase name="test::bin_does_not_rebuild_tests" time="0" />
-    <testcase name="test::bin_without_name" time="0" />
-    <testcase name="support::resolver::meta_test_multiple_versions_strategy" time="0" />
-    <testcase name="test::bin_there_for_integration" time="0" />
-    <testcase name="small_fd_limits::use_git_gc" time="0" />
-    <testcase name="test::cargo_test_env" time="0" />
-    <testcase name="test::build_then_selective_test" time="0" />
-    <testcase name="test::cargo_test_failing_test_in_lib" time="0" />
-    <testcase name="test::cargo_test_overflow_checks" time="0" />
-    <testcase name="test::cargo_test_failing_test_in_bin" time="0" />
-    <testcase name="test::can_not_mix_doc_tests_and_regular_tests" time="0" />
-    <testcase name="test::cargo_test_failing_test_in_test" time="0" />
-    <testcase name="test::cargo_test_simple" time="0" />
-    <testcase name="test::cargo_test_release" time="0" />
-    <testcase name="test::cargo_test_verbose" time="0" />
-    <testcase name="test::cargo_test_twice" time="0" />
-    <testcase name="test::cfg_test_even_with_no_harness" time="0" />
-    <testcase name="test::cyclic_dev" time="0" />
-    <testcase name="test::dashes_to_underscores" time="0" />
-    <testcase name="test::dev_dep_with_build_script" time="0" />
-    <testcase name="test::cyclic_dev_dep_doc_test" time="0" />
-    <testcase name="test::doctest_only_with_dev_dep" time="0" />
-    <testcase name="test::doctest_dev_dep" time="0" />
-    <testcase name="test::doctest_feature" time="0" />
-    <testcase name="test::doctest_and_registry" time="0" />
-    <testcase name="test::dylib_doctest2" time="0" />
-    <testcase name="test::doctest_skip_staticlib" time="0" />
-    <testcase name="test::dont_run_examples" time="0" />
-    <testcase name="test::dylib_doctest" time="0" />
-    <testcase name="test::example_without_name" time="0" />
-    <testcase name="test::example_bin_same_name" time="0" />
-    <testcase name="test::example_with_dev_dep" time="0" />
-    <testcase name="test::example_dev_dep" time="0" />
-    <testcase name="test::external_test_explicit" time="0" />
-    <testcase name="test::external_test_implicit" time="0" />
-    <testcase name="test::external_test_named_test" time="0" />
-    <testcase name="test::filter_no_doc_tests" time="0" />
-    <testcase name="test::json_artifact_includes_executable_for_integration_tests" time="0" />
-    <testcase name="test::json_artifact_includes_executable_for_library_tests" time="0" />
-    <testcase name="test::json_artifact_includes_test_flag" time="0" />
-    <testcase name="test::lib_bin_same_name" time="0" />
-    <testcase name="test::lib_with_standard_name2" time="0" />
-    <testcase name="test::find_dependency_of_proc_macro_dependency_with_target" time="0" />
-    <testcase name="test::lib_with_standard_name" time="0" />
-    <testcase name="test::lib_without_name" time="0" />
-    <testcase name="test::many_similar_names" time="0" />
-    <testcase name="test::only_test_docs" time="0" />
-    <testcase name="test::no_fail_fast" time="0" />
-    <testcase name="test::panic_abort_multiple" time="0" />
-    <testcase name="test::selective_test_optional_dep" time="0" />
-    <testcase name="test::pass_correct_cfgs_flags_to_rustdoc" time="0" />
-    <testcase name="test::pass_through_command_line" time="0" />
-    <testcase name="test::selective_test_wonky_profile" time="0" />
-    <testcase name="test::publish_a_crate_without_tests" time="0" />
-    <testcase name="test::selective_testing_with_docs" time="0" />
-    <testcase name="test::test_all_exclude" time="0" />
-    <testcase name="test::test_all_targets_lib" time="0" />
-    <testcase name="test::selective_testing" time="0" />
-    <testcase name="test::test_all_member_dependency_same_name" time="0" />
-    <testcase name="test::test_dep_with_dev" time="0" />
-    <testcase name="test::test_all_virtual_manifest" time="0" />
-    <testcase name="test::test_all_workspace" time="0" />
-    <testcase name="test::test_build_script_links" time="0" />
-    <testcase name="test::test_hint_workspace" time="0" />
-    <testcase name="test::test_dylib" time="0" />
-    <testcase name="test::test_hint_not_masked_by_doctest" time="0" />
-    <testcase name="test::test_many_targets" time="0" />
-    <testcase name="test::test_many_with_features" time="0" />
-    <testcase name="test::test_multiple_packages" time="0" />
-    <testcase name="test::test_no_harness" time="0" />
-    <testcase name="test::test_no_run" time="0" />
-    <testcase name="test::test_panic_abort_with_dep" time="0" />
-    <testcase name="test::test_order" time="0" />
-    <testcase name="test::test_run_implicit_bench_target" time="0" />
-    <testcase name="test::test_run_implicit_bin_target" time="0" />
-    <testcase name="test::test_release_ignore_panic" time="0" />
-    <testcase name="test::test_run_specific_bin_target" time="0" />
-    <testcase name="test::test_run_implicit_test_target" time="0" />
-    <testcase name="test::test_run_specific_test_target" time="0" />
-    <testcase name="test::test_then_build" time="0" />
-    <testcase name="test::test_virtual_manifest_all_implied" time="0" />
-    <testcase name="test::test_run_implicit_example_target" time="0" />
-    <testcase name="test::test_twice_with_build_cmd" time="0" />
-    <testcase name="test::test_without_name" time="0" />
-    <testcase name="test::test_with_example_twice" time="0" />
-    <testcase name="tool_paths::absolute_tools" time="0" />
-    <testcase name="test::test_with_deep_lib_dep" time="0" />
-    <testcase name="tool_paths::custom_runner_cfg_collision" time="0" />
-    <testcase name="tool_paths::custom_runner_cfg" time="0" />
-    <testcase name="test::test_with_lib_dep" time="0" />
-    <testcase name="tool_paths::pathless_tools" time="0" />
-    <testcase name="tool_paths::custom_runner_cfg_precedence" time="0" />
-    <testcase name="tool_paths::relative_tools" time="0" />
-    <testcase name="tool_paths::custom_runner" time="0" />
-    <testcase name="update::change_package_version" time="0" />
-    <testcase name="update::add_dep_deep_new_requirement" time="0" />
-    <testcase name="update::conservative" time="0" />
-    <testcase name="update::preserve_top_comment" time="0" />
-    <testcase name="update::dry_run_update" time="0" />
-    <testcase name="update::everything_real_deep" time="0" />
-    <testcase name="update::minor_update_two_places" time="0" />
-    <testcase name="update::update_precise" time="0" />
-    <testcase name="update::transitive_minor_update" time="0" />
-    <testcase name="verify_project::cargo_verify_project_cwd" time="0" />
-    <testcase name="verify_project::cargo_verify_project_path_to_cargo_toml_absolute" time="0" />
-    <testcase name="verify_project::cargo_verify_project_honours_unstable_features" time="0" />
-    <testcase name="verify_project::cargo_verify_project_path_to_cargo_toml_relative" time="0" />
-    <testcase name="version::version_works_with_bad_config" time="0" />
-    <testcase name="version::version_works_with_bad_target_dir" time="0" />
-    <testcase name="version::simple" time="0" />
-    <testcase name="update::update_via_new_dep" time="0" />
-    <testcase name="update::update_via_new_member" time="0" />
-    <testcase name="warn_on_failure::no_warning_on_bin_failure" time="0" />
-    <testcase name="warn_on_failure::warning_on_lib_failure" time="0" />
-    <testcase name="workspaces::cycle" time="0" />
-    <testcase name="workspaces::dangling_member" time="0" />
-    <testcase name="warn_on_failure::no_warning_on_success" time="0" />
-    <testcase name="workspaces::cargo_home_at_root_works" time="0" />
-    <testcase name="workspaces::bare_workspace_ok" time="0" />
-    <testcase name="workspaces::error_if_parent_cargo_toml_is_invalid" time="0" />
-    <testcase name="workspaces::dont_recurse_out_of_cargo_home" time="0" />
-    <testcase name="workspaces::exclude_members_preferred" time="0" />
-    <testcase name="workspaces::dep_used_with_separate_features" time="0" />
-    <testcase name="workspaces::exclude_but_also_depend" time="0" />
-    <testcase name="workspaces::explicit_package_argument_works_with_virtual_manifest" time="0" />
-    <testcase name="workspaces::glob_syntax_invalid_members" time="0" />
-    <testcase name="workspaces::excluded_simple" time="0" />
-    <testcase name="workspaces::include_virtual" time="0" />
-    <testcase name="workspaces::fetch_fetches_all" time="0" />
-    <testcase name="workspaces::invalid_members" time="0" />
-    <testcase name="workspaces::invalid_parent_pointer" time="0" />
-    <testcase name="workspaces::inferred_root" time="0" />
-    <testcase name="workspaces::inferred_path_dep" time="0" />
-    <testcase name="workspaces::lock_doesnt_change_depending_on_crate" time="0" />
-    <testcase name="workspaces::glob_syntax" time="0" />
-    <testcase name="workspaces::new_warns_you_this_will_not_work" time="0" />
-    <testcase name="workspaces::lockfile_can_specify_nonexistant_members" time="0" />
-    <testcase name="workspaces::parent_doesnt_point_to_child" time="0" />
-    <testcase name="workspaces::path_dep_outside_workspace_is_not_member" time="0" />
-    <testcase name="workspaces::members_include_path_deps" time="0" />
-    <testcase name="workspaces::lock_works_for_everyone" time="0" />
-    <testcase name="workspaces::parent_pointer_works" time="0" />
-    <testcase name="workspaces::relative_path_for_root_works" time="0" />
-    <testcase name="workspaces::same_names_in_workspace" time="0" />
-    <testcase name="workspaces::relative_path_for_member_works" time="0" />
-    <testcase name="workspaces::rebuild_please" time="0" />
-    <testcase name="workspaces::simple_explicit" time="0" />
-    <testcase name="workspaces::relative_rustc" time="0" />
-    <testcase name="workspaces::share_dependencies" time="0" />
-    <testcase name="workspaces::simple_explicit_default_members" time="0" />
-    <testcase name="workspaces::two_roots" time="0" />
-    <testcase name="workspaces::test_path_dependency_under_member" time="0" />
-    <testcase name="workspaces::virtual_build_no_members" time="0" />
-    <testcase name="workspaces::virtual_default_member_is_not_a_member" time="0" />
-    <testcase name="workspaces::virtual_build_all_implied" time="0" />
-    <testcase name="workspaces::test_in_and_out_of_workspace" time="0" />
-    <testcase name="workspaces::virtual_misconfigure" time="0" />
-    <testcase name="workspaces::virtual_default_members" time="0" />
-    <testcase name="workspaces::workspace_isnt_root" time="0" />
-    <testcase name="workspaces::transitive_path_dep" time="0" />
-    <testcase name="workspaces::virtual_works" time="0" />
-    <testcase name="workspaces::ws_rustc_err" time="0" />
-    <testcase name="workspaces::workspace_in_git" time="0" />
-    <testcase name="workspaces::ws_err_unused" time="0" />
-    <testcase name="workspaces::you_cannot_generate_lockfile_for_empty_workspaces" time="0" />
-    <testcase name="workspaces::ws_warn_path" time="0" />
-    <testcase name="workspaces::workspace_with_transitive_dev_deps" time="0" />
-    <testcase name="workspaces::ws_warn_unused" time="0" />
-    <system-out />
-    <system-err />
+    <testcase name="build_lib_only" classname="build_lib" time="0" />
+    <testcase name="https_something_happens" classname="build_auth" time="0" />
+    <testcase name="cargo_build_plan_build_script" classname="build_plan" time="0" />
+    <testcase name="build_with_relative_cargo_home_path" classname="build_lib" time="0" />
+    <testcase name="cargo_build_plan_simple" classname="build_plan" time="0" />
+    <testcase name="build_plan_with_dev_dep" classname="build_plan" time="0" />
+    <testcase name="cargo_build_plan_single_dep" classname="build_plan" time="0" />
+    <testcase name="adding_an_override_invalidates" classname="build_script" time="0" />
+    <testcase name="assume_build_script_when_build_rs_present" classname="build_script" time="0" />
+    <testcase name="build_script_only" classname="build_script" time="0" />
+    <testcase name="build_deps_not_for_normal" classname="build_script" time="0" />
+    <testcase name="build_cmd_with_a_build_cmd" classname="build_script" time="0" />
+    <testcase name="build_deps_simple" classname="build_script" time="0" />
+    <testcase name="build_script_with_lto" classname="build_script" time="0" />
+    <testcase name="cfg_feedback" classname="build_script" time="0" />
+    <testcase name="cfg_env_vars_available" classname="build_script" time="0" />
+    <testcase name="build_script_with_dynamic_native_dependency" classname="build_script" time="0" />
+    <testcase name="cfg_override" classname="build_script" time="0" />
+    <testcase name="cfg_override_test" classname="build_script" time="0" />
+    <testcase name="cfg_test" classname="build_script" time="0" />
+    <testcase name="custom_build_env_var_rustc_linker" classname="build_script" time="0" />
+    <testcase name="changing_an_override_invalidates" classname="build_script" time="0" />
+    <testcase name="cfg_doc" classname="build_script" time="0" />
+    <testcase name="custom_build_script_failed" classname="build_script" time="0" />
+    <testcase name="custom_build_script_wrong_rustc_flags" classname="build_script" time="0" />
+    <testcase name="custom_build_env_vars" classname="build_script" time="0" />
+    <testcase name="cfg_override_doc" classname="build_script" time="0" />
+    <testcase name="custom_target_dir" classname="build_script" time="0" />
+    <testcase name="diamond_passes_args_only_once" classname="build_script" time="0" />
+    <testcase name="deterministic_rustc_dependency_flags" classname="build_script" time="0" />
+    <testcase name="env_build" classname="build_script" time="0" />
+    <testcase name="doctest_receives_build_link_args" classname="build_script" time="0" />
+    <testcase name="fresh_builds_possible_with_link_libs" classname="build_script" time="0" />
+    <testcase name="fresh_builds_possible_with_multiple_metadata_overrides" classname="build_script" time="0" />
+    <testcase name="env_test" classname="build_script" time="0" />
+    <testcase name="links_duplicates" classname="build_script" time="0" />
+    <testcase name="links_duplicates_deep_dependency" classname="build_script" time="0" />
+    <testcase name="links_duplicates_with_cycle" classname="build_script" time="0" />
+    <testcase name="flags_go_into_tests" classname="build_script" time="0" />
+    <testcase name="if_build_set_to_false_dont_treat_build_rs_as_build_script" classname="build_script" time="0" />
+    <testcase name="links_no_build_cmd" classname="build_script" time="0" />
+    <testcase name="env_doc" classname="build_script" time="0" />
+    <testcase name="links_with_dots" classname="build_script" time="0" />
+    <testcase name="links_passes_env_vars" classname="build_script" time="0" />
+    <testcase name="non_utf8_output" classname="build_script" time="0" />
+    <testcase name="only_rerun_build_script" classname="build_script" time="0" />
+    <testcase name="output_separate_lines" classname="build_script" time="0" />
+    <testcase name="optional_build_dep_and_required_normal_dep" classname="build_script" time="0" />
+    <testcase name="out_dir_is_preserved" classname="build_script" time="0" />
+    <testcase name="optional_build_script_dep" classname="build_script" time="0" />
+    <testcase name="output_separate_lines_new" classname="build_script" time="0" />
+    <testcase name="output_shows_on_vv" classname="build_script" time="0" />
+    <testcase name="overrides_and_links" classname="build_script" time="0" />
+    <testcase name="please_respect_the_dag" classname="build_script" time="0" />
+    <testcase name="profile_debug_0" classname="build_script" time="0" />
+    <testcase name="profile_and_opt_level_set_correctly" classname="build_script" time="0" />
+    <testcase name="propagation_of_l_flags" classname="build_script" time="0" />
+    <testcase name="panic_abort_with_build_scripts" classname="build_script" time="0" />
+    <testcase name="propagation_of_l_flags_new" classname="build_script" time="0" />
+    <testcase name="rebuild_continues_to_pass_env_vars" classname="build_script" time="0" />
+    <testcase name="rename_with_link_search_path_cross" classname="build_script" time="0" />
+    <testcase name="release_with_build_script" classname="build_script" time="0" />
+    <testcase name="rustc_and_rustdoc_set_correctly" classname="build_script" time="0" />
+    <testcase name="shared_dep_with_a_build_script" classname="build_script" time="0" />
+    <testcase name="rename_with_link_search_path" classname="build_script" time="0" />
+    <testcase name="rebuild_only_on_explicit_paths" classname="build_script" time="0" />
+    <testcase name="test_dev_dep_build_script" classname="build_script" time="0" />
+    <testcase name="switch_features_rerun" classname="build_script" time="0" />
+    <testcase name="test_a_lib_with_a_build_command" classname="build_script" time="0" />
+    <testcase name="test_duplicate_deps" classname="build_script" time="0" />
+    <testcase name="unused_overrides" classname="build_script" time="0" />
+    <testcase name="warnings_emitted" classname="build_script" time="0" />
+    <testcase name="transitive_dep_host" classname="build_script" time="0" />
+    <testcase name="warnings_hidden_for_upstream" classname="build_script" time="0" />
+    <testcase name="warnings_printed_on_vv" classname="build_script" time="0" />
+    <testcase name="alias_cannot_shadow_builtin_command" classname="cargo_alias_config" time="0" />
+    <testcase name="rerun_if_env_changes" classname="build_script_env" time="0" />
+    <testcase name="alias_incorrect_config_type" classname="cargo_alias_config" time="0" />
+    <testcase name="testing_and_such" classname="build_script" time="0" />
+    <testcase name="alias_config" classname="cargo_alias_config" time="0" />
+    <testcase name="alias_list_test" classname="cargo_alias_config" time="0" />
+    <testcase name="alias_override_builtin_alias" classname="cargo_alias_config" time="0" />
+    <testcase name="alias_with_flags_config" classname="cargo_alias_config" time="0" />
+    <testcase name="rerun_if_env_or_file_changes" classname="build_script_env" time="0" />
+    <testcase name="cargo_help" classname="cargo_command" time="0" />
+    <testcase name="recursive_alias" classname="cargo_alias_config" time="0" />
+    <testcase name="builtin_alias_takes_options" classname="cargo_alias_config" time="0" />
+    <testcase name="displays_subcommand_on_error" classname="cargo_command" time="0" />
+    <testcase name="explain" classname="cargo_command" time="0" />
+    <testcase name="cargo_subcommand_args" classname="cargo_command" time="0" />
+    <testcase name="find_closest_dont_correct_nonsense" classname="cargo_command" time="0" />
+    <testcase name="cargo_subcommand_env" classname="cargo_command" time="0" />
+    <testcase name="list_command_looks_at_path" classname="cargo_command" time="0" />
+    <testcase name="list_commands_with_descriptions" classname="cargo_command" time="0" />
+    <testcase name="override_cargo_home" classname="cargo_command" time="0" />
+    <testcase name="z_flags_help" classname="cargo_command" time="0" />
+    <testcase name="cargo_help_external_subcommand" classname="cargo_command" time="0" />
+    <testcase name="feature_required" classname="cargo_features" time="0" />
+    <testcase name="cant_publish" classname="cargo_features" time="0" />
+    <testcase name="nightly_feature_requires_nightly" classname="cargo_features" time="0" />
+    <testcase name="nightly_feature_requires_nightly_in_dep" classname="cargo_features" time="0" />
+    <testcase name="find_closest_biuld_to_build" classname="cargo_command" time="0" />
+    <testcase name="unknown_feature" classname="cargo_features" time="0" />
+    <testcase name="stable_feature_warns" classname="cargo_features" time="0" />
+    <testcase name="bad_target_spec" classname="cfg" time="0" />
+    <testcase name="bad_target_spec2" classname="cfg" time="0" />
+    <testcase name="z_flags_rejected" classname="cargo_features" time="0" />
+    <testcase name="cfg_expr" classname="cfg" time="0" />
+    <testcase name="cfg_expr_bad" classname="cfg" time="0" />
+    <testcase name="cfg_matches" classname="cfg" time="0" />
+    <testcase name="publish_allowed" classname="cargo_features" time="0" />
+    <testcase name="cfg_syntax" classname="cfg" time="0" />
+    <testcase name="cfg_syntax_bad" classname="cfg" time="0" />
+    <testcase name="any_ok" classname="cfg" time="0" />
+    <testcase name="cfg_easy" classname="cfg" time="0" />
+    <testcase name="dont_include" classname="cfg" time="0" />
+    <testcase name="multiple_match_ok" classname="cfg" time="0" />
+    <testcase name="ignore_version_from_other_platform" classname="cfg" time="0" />
+    <testcase name="check_all" classname="check" time="0" />
+    <testcase name="build_check" classname="check" time="0" />
+    <testcase name="works_through_the_registry" classname="cfg" time="0" />
+    <testcase name="check_fail" classname="check" time="0" />
+    <testcase name="check_build" classname="check" time="0" />
+    <testcase name="check_success" classname="check" time="0" />
+    <testcase name="check_unit_test_profile" classname="check" time="0" />
+    <testcase name="check_virtual_all_implied" classname="check" time="0" />
+    <testcase name="does_not_use_empty_rustc_wrapper" classname="check" time="0" />
+    <testcase name="custom_derive" classname="check" time="0" />
+    <testcase name="check_artifacts" classname="check" time="0" />
+    <testcase name="check_filters" classname="check" time="0" />
+    <testcase name="dylib_check_preserves_build_cache" classname="check" time="0" />
+    <testcase name="issue_3418" classname="check" time="0" />
+    <testcase name="issue_3419" classname="check" time="0" />
+    <testcase name="rustc_check" classname="check" time="0" />
+    <testcase name="proc_macro" classname="check" time="0" />
+    <testcase name="rustc_check_err" classname="check" time="0" />
+    <testcase name="short_message_format" classname="check" time="0" />
+    <testcase name="targets_selected_all" classname="check" time="0" />
+    <testcase name="error_from_deep_recursion" classname="check" time="0" />
+    <testcase name="targets_selected_default" classname="check" time="0" />
+    <testcase name="cargo_clean_simple" classname="clean" time="0" />
+    <testcase name="clean_multiple_packages" classname="clean" time="0" />
+    <testcase name="build_script" classname="clean" time="0" />
+    <testcase name="clean_git" classname="clean" time="0" />
+    <testcase name="different_dir" classname="clean" time="0" />
+    <testcase name="clean_verbose" classname="clean" time="0" />
+    <testcase name="clean_release" classname="clean" time="0" />
+    <testcase name="collision_example" classname="collisions" time="0" />
+    <testcase name="registry" classname="clean" time="0" />
+    <testcase name="collision_dylib" classname="collisions" time="0" />
+    <testcase name="clean_doc" classname="clean" time="0" />
+    <testcase name="collision_export" classname="collisions" time="0" />
+    <testcase name="concurrent_installs" classname="concurrent" time="0" />
+    <testcase name="debug_release_ok" classname="concurrent" time="0" />
+    <testcase name="multiple_installs" classname="concurrent" time="0" />
+    <testcase name="git_same_repo_different_tags" classname="concurrent" time="0" />
+    <testcase name="git_same_branch_different_revs" classname="concurrent" time="0" />
+    <testcase name="one_install_should_be_bad" classname="concurrent" time="0" />
+    <testcase name="config_bad_toml" classname="config" time="0" />
+    <testcase name="config_deserialize_any" classname="config" time="0" />
+    <testcase name="config_get_integers" classname="config" time="0" />
+    <testcase name="config_get_list" classname="config" time="0" />
+    <testcase name="config_get_option" classname="config" time="0" />
+    <testcase name="config_get_other_types" classname="config" time="0" />
+    <testcase name="config_load_toml_profile" classname="config" time="0" />
+    <testcase name="config_relative_path" classname="config" time="0" />
+    <testcase name="config_toml_errors" classname="config" time="0" />
+    <testcase name="config_unused_fields" classname="config" time="0" />
+    <testcase name="get_config" classname="config" time="0" />
+    <testcase name="get_errors" classname="config" time="0" />
+    <testcase name="same_project" classname="concurrent" time="0" />
+    <testcase name="load_nested" classname="config" time="0" />
+    <testcase name="no_deadlock_with_git_dependencies" classname="concurrent" time="0" />
+    <testcase name="multiple_registry_fetches" classname="concurrent" time="0" />
+    <testcase name="build_deps_for_the_right_arch" classname="cross_compile" time="0" />
+    <testcase name="build_script_needed_for_host_and_target" classname="cross_compile" time="0" />
+    <testcase name="build_script_only_host" classname="cross_compile" time="0" />
+    <testcase name="build_script_with_platform_specific_dependencies" classname="cross_compile" time="0" />
+    <testcase name="cross_test_dylib" classname="cross_compile" time="0" />
+    <testcase name="cross_tests" classname="cross_compile" time="0" />
+    <testcase name="cross_with_a_build_script" classname="cross_compile" time="0" />
+    <testcase name="linker_and_ar" classname="cross_compile" time="0" />
+    <testcase name="no_cross_doctests" classname="cross_compile" time="0" />
+    <testcase name="platform_specific_dependencies_do_not_leak" classname="cross_compile" time="0" />
+    <testcase name="platform_specific_variables_reflected_in_build_scripts" classname="cross_compile" time="0" />
+    <testcase name="plugin_build_script_right_arch" classname="cross_compile" time="0" />
+    <testcase name="plugin_deps" classname="cross_compile" time="0" />
+    <testcase name="plugin_to_the_max" classname="cross_compile" time="0" />
+    <testcase name="plugin_with_extra_dylib_dep" classname="cross_compile" time="0" />
+    <testcase name="simple_cargo_run" classname="cross_compile" time="0" />
+    <testcase name="simple_cross" classname="cross_compile" time="0" />
+    <testcase name="simple_cross_config" classname="cross_compile" time="0" />
+    <testcase name="simple_deps" classname="cross_compile" time="0" />
+    <testcase name="publish_with_target" classname="cross_publish" time="0" />
+    <testcase name="simple_cross_package" classname="cross_publish" time="0" />
+    <testcase name="custom_target_dependency" classname="custom_target" time="0" />
+    <testcase name="custom_target_minimal" classname="custom_target" time="0" />
+    <testcase name="read_env_vars_for_config" classname="config" time="0" />
+    <testcase name="build_dep_info" classname="dep_info" time="0" />
+    <testcase name="ctrl_c_kills_everyone" classname="death" time="0" />
+    <testcase name="deleting_database_files" classname="corrupt_git" time="0" />
+    <testcase name="build_dep_info_lib" classname="dep_info" time="0" />
+    <testcase name="build_dep_info_dylib" classname="dep_info" time="0" />
+    <testcase name="deleting_checkout_files" classname="corrupt_git" time="0" />
+    <testcase name="bad_file_checksum" classname="directory" time="0" />
+    <testcase name="build_dep_info_rlib" classname="dep_info" time="0" />
+    <testcase name="no_rewrite_if_no_change" classname="dep_info" time="0" />
+    <testcase name="git_override_requires_lockfile" classname="directory" time="0" />
+    <testcase name="crates_io_then_bad_checksum" classname="directory" time="0" />
+    <testcase name="git_lock_file_doesnt_change" classname="directory" time="0" />
+    <testcase name="install_without_feature_dep" classname="directory" time="0" />
+    <testcase name="not_there" classname="directory" time="0" />
+    <testcase name="crates_io_then_directory" classname="directory" time="0" />
+    <testcase name="multiple" classname="directory" time="0" />
+    <testcase name="only_dot_files_ok" classname="directory" time="0" />
+    <testcase name="random_files_ok" classname="directory" time="0" />
+    <testcase name="simple_install_fail" classname="directory" time="0" />
+    <testcase name="simple" classname="directory" time="0" />
+    <testcase name="version_missing" classname="directory" time="0" />
+    <testcase name="doc_all_member_dependency_same_name" classname="doc" time="0" />
+    <testcase name="simple_install" classname="directory" time="0" />
+    <testcase name="doc_cap_lints" classname="doc" time="0" />
+    <testcase name="workspace_different_locations" classname="directory" time="0" />
+    <testcase name="doc_all_virtual_manifest" classname="doc" time="0" />
+    <testcase name="doc_edition" classname="doc" time="0" />
+    <testcase name="doc_all_workspace" classname="doc" time="0" />
+    <testcase name="doc_lib_bin_same_name_documents_bins_when_requested" classname="doc" time="0" />
+    <testcase name="doc_dash_p" classname="doc" time="0" />
+    <testcase name="doc_deps" classname="doc" time="0" />
+    <testcase name="doc_message_format" classname="doc" time="0" />
+    <testcase name="doc_lib_bin_same_name_documents_lib" classname="doc" time="0" />
+    <testcase name="doc_lib_bin_same_name_documents_lib_when_requested" classname="doc" time="0" />
+    <testcase name="doc_multiple_targets_same_name_bin" classname="doc" time="0" />
+    <testcase name="doc_multiple_targets_same_name_lib" classname="doc" time="0" />
+    <testcase name="doc_lib_bin_same_name_documents_named_bin_when_requested" classname="doc" time="0" />
+    <testcase name="doc_multiple_deps" classname="doc" time="0" />
+    <testcase name="doc_no_libs" classname="doc" time="0" />
+    <testcase name="doc_multiple_targets_same_name" classname="doc" time="0" />
+    <testcase name="doc_multiple_targets_same_name_undoced" classname="doc" time="0" />
+    <testcase name="doc_no_deps" classname="doc" time="0" />
+    <testcase name="doc_private_items" classname="doc" time="0" />
+    <testcase name="doc_private_ws" classname="doc" time="0" />
+    <testcase name="doc_release" classname="doc" time="0" />
+    <testcase name="doc_target_edition" classname="doc" time="0" />
+    <testcase name="doc_target" classname="doc" time="0" />
+    <testcase name="doc_only_bin" classname="doc" time="0" />
+    <testcase name="doc_same_name" classname="doc" time="0" />
+    <testcase name="doc_twice" classname="doc" time="0" />
+    <testcase name="doc_virtual_manifest_all_implied" classname="doc" time="0" />
+    <testcase name="doc_workspace_open_help_message" classname="doc" time="0" />
+    <testcase name="document_only_lib" classname="doc" time="0" />
+    <testcase name="no_document_build_deps" classname="doc" time="0" />
+    <testcase name="plugins_no_use_target" classname="doc" time="0" />
+    <testcase name="features" classname="doc" time="0" />
+    <testcase name="short_message_format" classname="doc" time="0" />
+    <testcase name="issue_5345" classname="doc" time="0" />
+    <testcase name="output_not_captured" classname="doc" time="0" />
+    <testcase name="rerun_when_dir_removed" classname="doc" time="0" />
+    <testcase name="edition_works_for_build_script" classname="edition" time="0" />
+    <testcase name="simple" classname="doc" time="0" />
+    <testcase name="activating_feature_activates_dep" classname="features" time="0" />
+    <testcase name="target_specific_not_documented" classname="doc" time="0" />
+    <testcase name="all_features_all_crates" classname="features" time="0" />
+    <testcase name="cyclic_feature" classname="features" time="0" />
+    <testcase name="all_features_flag_enables_all_features" classname="features" time="0" />
+    <testcase name="cyclic_feature2" classname="features" time="0" />
+    <testcase name="target_specific_documented" classname="doc" time="0" />
+    <testcase name="combining_features_and_package" classname="features" time="0" />
+    <testcase name="everything_in_the_lockfile" classname="features" time="0" />
+    <testcase name="empty_features" classname="features" time="0" />
+    <testcase name="default_feature_pulled_in" classname="features" time="0" />
+    <testcase name="invalid1" classname="features" time="0" />
+    <testcase name="dep_feature_in_cmd_line" classname="features" time="0" />
+    <testcase name="invalid2" classname="features" time="0" />
+    <testcase name="invalid3" classname="features" time="0" />
+    <testcase name="groups_on_groups_on_groups" classname="features" time="0" />
+    <testcase name="invalid4" classname="features" time="0" />
+    <testcase name="invalid5" classname="features" time="0" />
+    <testcase name="invalid6" classname="features" time="0" />
+    <testcase name="invalid7" classname="features" time="0" />
+    <testcase name="invalid8" classname="features" time="0" />
+    <testcase name="invalid10" classname="features" time="0" />
+    <testcase name="feature_off_dylib" classname="features" time="0" />
+    <testcase name="invalid9" classname="features" time="0" />
+    <testcase name="many_cli_features" classname="features" time="0" />
+    <testcase name="many_cli_features_comma_and_space_delimited" classname="features" time="0" />
+    <testcase name="namespaced_implicit_non_optional" classname="features" time="0" />
+    <testcase name="many_cli_features_comma_delimited" classname="features" time="0" />
+    <testcase name="namespaced_invalid_dependency" classname="features" time="0" />
+    <testcase name="namespaced_invalid_feature" classname="features" time="0" />
+    <testcase name="namespaced_non_optional_dependency" classname="features" time="0" />
+    <testcase name="namespaced_shadowed_dep" classname="features" time="0" />
+    <testcase name="namespaced_shadowed_non_optional" classname="features" time="0" />
+    <testcase name="namespaced_implicit_feature" classname="features" time="0" />
+    <testcase name="many_features_no_rebuilds" classname="features" time="0" />
+    <testcase name="no_transitive_dep_feature_requirement" classname="features" time="0" />
+    <testcase name="namespaced_same_name" classname="features" time="0" />
+    <testcase name="optional_and_dev_dep" classname="features" time="0" />
+    <testcase name="no_rebuild_when_frobbing_default_feature" classname="features" time="0" />
+    <testcase name="no_feature_doesnt_build" classname="features" time="0" />
+    <testcase name="only_dep_is_optional" classname="features" time="0" />
+    <testcase name="transitive_features" classname="features" time="0" />
+    <testcase name="fetch_all_platform_dependencies_when_no_target_is_given" classname="fetch" time="0" />
+    <testcase name="fetch_platform_specific_dependencies" classname="fetch" time="0" />
+    <testcase name="no_deps" classname="fetch" time="0" />
+    <testcase name="union_features" classname="features" time="0" />
+    <testcase name="both_edition_migrate_flags" classname="fix" time="0" />
+    <testcase name="unions_work_with_no_default_features" classname="features" time="0" />
+    <testcase name="warn_if_default_features" classname="features" time="0" />
+    <testcase name="does_not_crash_with_rustc_wrapper" classname="fix" time="0" />
+    <testcase name="do_not_fix_non_relevant_deps" classname="fix" time="0" />
+    <testcase name="do_not_fix_broken_builds" classname="fix" time="0" />
+    <testcase name="does_not_warn_about_clean_working_directory" classname="fix" time="0" />
+    <testcase name="does_not_warn_about_dirty_ignored_files" classname="fix" time="0" />
+    <testcase name="fix_all_targets_by_default" classname="fix" time="0" />
+    <testcase name="doesnt_rebuild_dependencies" classname="fix" time="0" />
+    <testcase name="broken_fixes_backed_out" classname="fix" time="0" />
+    <testcase name="fix_broken_if_requested" classname="fix" time="0" />
+    <testcase name="fix_deny_warnings" classname="fix" time="0" />
+    <testcase name="fix_idioms" classname="fix" time="0" />
+    <testcase name="fix_overlapping" classname="fix" time="0" />
+    <testcase name="fix_to_broken_code" classname="fix" time="0" />
+    <testcase name="fix_deny_warnings_but_not_others" classname="fix" time="0" />
+    <testcase name="fix_two_files" classname="fix" time="0" />
+    <testcase name="fix_path_deps" classname="fix" time="0" />
+    <testcase name="fix_with_common" classname="fix" time="0" />
+    <testcase name="fix_features" classname="fix" time="0" />
+    <testcase name="fixes_extra_mut" classname="fix" time="0" />
+    <testcase name="local_paths" classname="fix" time="0" />
+    <testcase name="fixes_two_missing_ampersands" classname="fix" time="0" />
+    <testcase name="idioms_2015_ok" classname="fix" time="0" />
+    <testcase name="prepare_for_2018" classname="fix" time="0" />
+    <testcase name="no_changes_necessary" classname="fix" time="0" />
+    <testcase name="prepare_for_and_enable" classname="fix" time="0" />
+    <testcase name="only_warn_for_relevant_crates" classname="fix" time="0" />
+    <testcase name="preserve_line_endings" classname="fix" time="0" />
+    <testcase name="shows_warnings" classname="fix" time="0" />
+    <testcase name="specify_rustflags" classname="fix" time="0" />
+    <testcase name="shows_warnings_on_second_run_without_changes" classname="fix" time="0" />
+    <testcase name="tricky" classname="fix" time="0" />
+    <testcase name="upgrade_extern_crate" classname="fix" time="0" />
+    <testcase name="warns_about_dirty_working_directory" classname="fix" time="0" />
+    <testcase name="fixes_missing_ampersand" classname="fix" time="0" />
+    <testcase name="warns_about_staged_working_directory" classname="fix" time="0" />
+    <testcase name="shows_warnings_on_second_run_without_changes_on_multiple_targets" classname="fix" time="0" />
+    <testcase name="warns_if_no_vcs_detected" classname="fix" time="0" />
+    <testcase name="change_panic_mode" classname="freshness" time="0" />
+    <testcase name="bust_patched_dep" classname="freshness" time="0" />
+    <testcase name="changing_bin_features_caches_targets" classname="freshness" time="0" />
+    <testcase name="changing_lib_features_caches_targets" classname="freshness" time="0" />
+    <testcase name="changing_rustflags_is_cached" classname="freshness" time="0" />
+    <testcase name="changing_profiles_caches_targets" classname="freshness" time="0" />
+    <testcase name="dont_rebuild_based_on_plugins" classname="freshness" time="0" />
+    <testcase name="fingerprint_cleaner_does_not_rebuild" classname="freshness" time="0" />
+    <testcase name="modifying_and_moving" classname="freshness" time="0" />
+    <testcase name="no_rebuild_if_build_artifacts_move_backwards_in_time" classname="freshness" time="0" />
+    <testcase name="changing_bin_paths_common_target_features_caches_targets" classname="freshness" time="0" />
+    <testcase name="no_rebuild_when_rename_dir" classname="freshness" time="0" />
+    <testcase name="modify_only_some_files" classname="freshness" time="0" />
+    <testcase name="no_rebuild_transitive_target_deps" classname="freshness" time="0" />
+    <testcase name="path_dev_dep_registry_updates" classname="freshness" time="0" />
+    <testcase name="rebuild_if_build_artifacts_move_forward_in_time" classname="freshness" time="0" />
+    <testcase name="rebuild_if_environment_changes" classname="freshness" time="0" />
+    <testcase name="rebuild_sub_package_then_while_package" classname="freshness" time="0" />
+    <testcase name="rebuild_on_mid_build_file_modification" classname="freshness" time="0" />
+    <testcase name="rerun_if_changed_in_dep" classname="freshness" time="0" />
+    <testcase name="reuse_panic_build_dep_test" classname="freshness" time="0" />
+    <testcase name="reuse_panic_pm" classname="freshness" time="0" />
+    <testcase name="reuse_shared_build_dep" classname="freshness" time="0" />
+    <testcase name="rebuild_tests_if_lib_changes" classname="freshness" time="0" />
+    <testcase name="reuse_workspace_lib" classname="freshness" time="0" />
+    <testcase name="same_build_dir_cached_packages" classname="freshness" time="0" />
+    <testcase name="adding_and_removing_packages" classname="generate_lockfile" time="0" />
+    <testcase name="cargo_update_generate_lockfile" classname="generate_lockfile" time="0" />
+    <testcase name="duplicate_entries_in_lockfile" classname="generate_lockfile" time="0" />
+    <testcase name="preserve_line_endings_issue_2076" classname="generate_lockfile" time="0" />
+    <testcase name="unused_optional_dep" classname="freshness" time="0" />
+    <testcase name="no_index_update" classname="generate_lockfile" time="0" />
+    <testcase name="cargo_compile_forbird_git_httpsrepo_offline" classname="git" time="0" />
+    <testcase name="simple_deps_cleaner_does_not_rebuild" classname="freshness" time="0" />
+    <testcase name="preserve_metadata" classname="generate_lockfile" time="0" />
+    <testcase name="add_a_git_dep" classname="git" time="0" />
+    <testcase name="cargo_compile_git_dep_branch" classname="git" time="0" />
+    <testcase name="cargo_compile_git_dep_tag" classname="git" time="0" />
+    <testcase name="cargo_compile_simple_git_dep" classname="git" time="0" />
+    <testcase name="cargo_compile_with_malformed_nested_paths" classname="git" time="0" />
+    <testcase name="cargo_compile_with_meta_package" classname="git" time="0" />
+    <testcase name="cargo_compile_with_short_ssh_git" classname="git" time="0" />
+    <testcase name="dep_with_bad_submodule" classname="git" time="0" />
+    <testcase name="denied_lints_are_allowed" classname="git" time="0" />
+    <testcase name="cargo_compile_with_nested_paths" classname="git" time="0" />
+    <testcase name="cargo_compile_offline_with_cached_git_dep" classname="git" time="0" />
+    <testcase name="dep_with_submodule" classname="git" time="0" />
+    <testcase name="dev_deps_with_testing" classname="git" time="0" />
+    <testcase name="doctest_same_name" classname="git" time="0" />
+    <testcase name="dont_require_submodules_are_checked_out" classname="git" time="0" />
+    <testcase name="failed_submodule_checkout" classname="git" time="0" />
+    <testcase name="fetch_downloads" classname="git" time="0" />
+    <testcase name="dep_with_changed_submodule" classname="git" time="0" />
+    <testcase name="git_name_not_always_needed" classname="git" time="0" />
+    <testcase name="invalid_git_dependency_manifest" classname="git" time="0" />
+    <testcase name="git_build_cmd_freshness" classname="git" time="0" />
+    <testcase name="git_dep_build_cmd" classname="git" time="0" />
+    <testcase name="lints_are_suppressed" classname="git" time="0" />
+    <testcase name="git_repo_changing_no_rebuild" classname="git" time="0" />
+    <testcase name="switch_deps_does_not_update_transitive" classname="git" time="0" />
+    <testcase name="stale_cached_version" classname="git" time="0" />
+    <testcase name="recompilation" classname="git" time="0" />
+    <testcase name="switch_sources" classname="git" time="0" />
+    <testcase name="templatedir_doesnt_cause_problems" classname="git" time="0" />
+    <testcase name="two_at_rev_instead_of_tag" classname="git" time="0" />
+    <testcase name="update_one_dep_in_repo_with_many_deps" classname="git" time="0" />
+    <testcase name="two_deps_only_update_one" classname="git" time="0" />
+    <testcase name="two_revs_same_deps" classname="git" time="0" />
+    <testcase name="update_ambiguous" classname="git" time="0" />
+    <testcase name="update_one_source_updates_all_packages_in_that_git_source" classname="git" time="0" />
+    <testcase name="warnings_in_git_dep" classname="git" time="0" />
+    <testcase name="bin_already_exists_explicit" classname="init" time="0" />
+    <testcase name="auto_git" classname="init" time="0" />
+    <testcase name="bin_already_exists_explicit_nosrc" classname="init" time="0" />
+    <testcase name="bin_already_exists_implicit" classname="init" time="0" />
+    <testcase name="bin_already_exists_implicit_namenosrc" classname="init" time="0" />
+    <testcase name="bin_already_exists_implicit_namesrc" classname="init" time="0" />
+    <testcase name="both_lib_and_bin" classname="init" time="0" />
+    <testcase name="bin_already_exists_implicit_nosrc" classname="init" time="0" />
+    <testcase name="use_the_cli" classname="git" time="0" />
+    <testcase name="cargo_lock_gitignored_if_lib1" classname="init" time="0" />
+    <testcase name="cargo_lock_gitignored_if_lib2" classname="init" time="0" />
+    <testcase name="cargo_lock_not_gitignored_if_bin1" classname="init" time="0" />
+    <testcase name="confused_by_multiple_lib_files" classname="init" time="0" />
+    <testcase name="cargo_lock_not_gitignored_if_bin2" classname="init" time="0" />
+    <testcase name="git_autodetect" classname="init" time="0" />
+    <testcase name="gitignore_added_newline_in_existing" classname="init" time="0" />
+    <testcase name="gitignore_appended_not_replaced" classname="init" time="0" />
+    <testcase name="gitignore_no_newline_in_new" classname="init" time="0" />
+    <testcase name="invalid_dir_name" classname="init" time="0" />
+    <testcase name="lib_already_exists_nosrc" classname="init" time="0" />
+    <testcase name="lib_already_exists_src" classname="init" time="0" />
+    <testcase name="mercurial_added_newline_in_existing" classname="init" time="0" />
+    <testcase name="mercurial_autodetect" classname="init" time="0" />
+    <testcase name="mercurial_no_newline_in_new" classname="init" time="0" />
+    <testcase name="reserved_name" classname="init" time="0" />
+    <testcase name="multibin_project_name_clash" classname="init" time="0" />
+    <testcase name="simple_git" classname="init" time="0" />
+    <testcase name="simple_git_ignore_exists" classname="init" time="0" />
+    <testcase name="unknown_flags" classname="init" time="0" />
+    <testcase name="with_argument" classname="init" time="0" />
+    <testcase name="simple_lib" classname="init" time="0" />
+    <testcase name="simple_bin" classname="init" time="0" />
+    <testcase name="bad_paths" classname="install" time="0" />
+    <testcase name="bad_version" classname="install" time="0" />
+    <testcase name="update_with_shared_deps" classname="git" time="0" />
+    <testcase name="compile_failure" classname="install" time="0" />
+    <testcase name="do_not_rebuilds_on_local_install" classname="install" time="0" />
+    <testcase name="dev_dependencies_no_check" classname="install" time="0" />
+    <testcase name="dev_dependencies_lock_file_untouched" classname="install" time="0" />
+    <testcase name="custom_target_dir_for_git_source" classname="install" time="0" />
+    <testcase name="examples" classname="install" time="0" />
+    <testcase name="install_empty_argument" classname="install" time="0" />
+    <testcase name="git_repo" classname="install" time="0" />
+    <testcase name="git_with_lockfile" classname="install" time="0" />
+    <testcase name="git_repo_replace" classname="install" time="0" />
+    <testcase name="install_force" classname="install" time="0" />
+    <testcase name="install_force_bin" classname="install" time="0" />
+    <testcase name="install_global_cargo_config" classname="install" time="0" />
+    <testcase name="install_force_partial_overlap" classname="install" time="0" />
+    <testcase name="install_ignores_local_cargo_config" classname="install" time="0" />
+    <testcase name="install_target_foreign" classname="install" time="0" />
+    <testcase name="install_path" classname="install" time="0" />
+    <testcase name="install_twice" classname="install" time="0" />
+    <testcase name="install_respects_lock_file" classname="install" time="0" />
+    <testcase name="install_target_native" classname="install" time="0" />
+    <testcase name="installs_from_cwd_with_2018_warnings" classname="install" time="0" />
+    <testcase name="installs_from_cwd_by_default" classname="install" time="0" />
+    <testcase name="installs_beta_version_by_explicit_name_from_git" classname="install" time="0" />
+    <testcase name="legacy_version_requirement" classname="install" time="0" />
+    <testcase name="install_location_precedence" classname="install" time="0" />
+    <testcase name="missing" classname="install" time="0" />
+    <testcase name="list_error" classname="install" time="0" />
+    <testcase name="lock_file_path_deps_ok" classname="install" time="0" />
+    <testcase name="multiple_crates_auto_binaries" classname="install" time="0" />
+    <testcase name="multiple_crates_error" classname="install" time="0" />
+    <testcase name="list" classname="install" time="0" />
+    <testcase name="multiple_crates_auto_examples" classname="install" time="0" />
+    <testcase name="no_binaries" classname="install" time="0" />
+    <testcase name="no_binaries_or_examples" classname="install" time="0" />
+    <testcase name="not_both_vers_and_version" classname="install" time="0" />
+    <testcase name="multiple_crates_git_all" classname="install" time="0" />
+    <testcase name="multiple_crates_select" classname="install" time="0" />
+    <testcase name="pick_max_version" classname="install" time="0" />
+    <testcase name="multiple_pkgs" classname="install" time="0" />
+    <testcase name="q_silences_warnings" classname="install" time="0" />
+    <testcase name="readonly_dir" classname="install" time="0" />
+    <testcase name="test_install_git_cannot_be_a_base_url" classname="install" time="0" />
+    <testcase name="simple" classname="install" time="0" />
+    <testcase name="reports_unsuccessful_subcommand_result" classname="install" time="0" />
+    <testcase name="uninstall_cwd_no_project" classname="install" time="0" />
+    <testcase name="uninstall_cwd_not_installed" classname="install" time="0" />
+    <testcase name="subcommand_works_out_of_the_box" classname="install" time="0" />
+    <testcase name="uninstall_multiple_and_specifying_bin" classname="install" time="0" />
+    <testcase name="uninstall_cwd" classname="install" time="0" />
+    <testcase name="uninstall_pkg_does_not_exist" classname="install" time="0" />
+    <testcase name="uninstall_bin_does_not_exist" classname="install" time="0" />
+    <testcase name="uninstall_piecemeal" classname="install" time="0" />
+    <testcase name="uninstall_multiple_and_some_pkg_does_not_exist" classname="install" time="0" />
+    <testcase name="vers_precise" classname="install" time="0" />
+    <testcase name="jobserver_and_j" classname="jobserver" time="0" />
+    <testcase name="use_path_workspace" classname="install" time="0" />
+    <testcase name="makes_jobserver_used" classname="jobserver" time="0" />
+    <testcase name="workspace_uses_workspace_target_dir" classname="install" time="0" />
+    <testcase name="version_too" classname="install" time="0" />
+    <testcase name="bench_list_targets" classname="list_targets" time="0" />
+    <testcase name="build_list_targets" classname="list_targets" time="0" />
+    <testcase name="doc_list_targets" classname="list_targets" time="0" />
+    <testcase name="check_list_targets" classname="list_targets" time="0" />
+    <testcase name="install_list_targets" classname="list_targets" time="0" />
+    <testcase name="run_list_targets" classname="list_targets" time="0" />
+    <testcase name="jobserver_exists" classname="jobserver" time="0" />
+    <testcase name="fix_list_targets" classname="list_targets" time="0" />
+    <testcase name="rustc_list_targets" classname="list_targets" time="0" />
+    <testcase name="rustdoc_list_targets" classname="list_targets" time="0" />
+    <testcase name="test_list_targets" classname="list_targets" time="0" />
+    <testcase name="invalid_dir_bad" classname="local_registry" time="0" />
+    <testcase name="different_directory_replacing_the_registry_is_bad" classname="local_registry" time="0" />
+    <testcase name="interdependent" classname="local_registry" time="0" />
+    <testcase name="multiple_names" classname="local_registry" time="0" />
+    <testcase name="crates_io_registry_url_is_optional" classname="local_registry" time="0" />
+    <testcase name="multiple_versions" classname="local_registry" time="0" />
+    <testcase name="path_dep_rewritten" classname="local_registry" time="0" />
+    <testcase name="current_lockfile_format" classname="lockfile_compat" time="0" />
+    <testcase name="listed_checksum_bad_if_we_cannot_compute" classname="lockfile_compat" time="0" />
+    <testcase name="locked_correct_error" classname="lockfile_compat" time="0" />
+    <testcase name="simple" classname="local_registry" time="0" />
+    <testcase name="frozen_flag_preserves_old_lockfile" classname="lockfile_compat" time="0" />
+    <testcase name="unlisted_checksum_is_bad_if_we_calculate" classname="lockfile_compat" time="0" />
+    <testcase name="lockfile_without_root" classname="lockfile_compat" time="0" />
+    <testcase name="totally_wild_checksums_works" classname="lockfile_compat" time="0" />
+    <testcase name="wrong_checksum_is_an_error" classname="lockfile_compat" time="0" />
+    <testcase name="login_with_new_credentials" classname="login" time="0" />
+    <testcase name="oldest_lockfile_still_works" classname="lockfile_compat" time="0" />
+    <testcase name="login_with_old_and_new_credentials" classname="login" time="0" />
+    <testcase name="new_credentials_is_used_instead_old" classname="login" time="0" />
+    <testcase name="login_with_old_credentials" classname="login" time="0" />
+    <testcase name="login_without_credentials" classname="login" time="0" />
+    <testcase name="toml_deserialize_manifest_error" classname="member_errors" time="0" />
+    <testcase name="member_manifest_path_io_error" classname="member_errors" time="0" />
+    <testcase name="registry_credentials" classname="login" time="0" />
+    <testcase name="metabuild_error_both" classname="metabuild" time="0" />
+    <testcase name="metabuild_build_plan" classname="metabuild" time="0" />
+    <testcase name="metabuild_basic" classname="metabuild" time="0" />
+    <testcase name="member_manifest_version_error" classname="member_errors" time="0" />
+    <testcase name="metabuild_gated" classname="metabuild" time="0" />
+    <testcase name="metabuild_failed_build_json" classname="metabuild" time="0" />
+    <testcase name="metabuild_external_dependency" classname="metabuild" time="0" />
+    <testcase name="metabuild_fresh" classname="metabuild" time="0" />
+    <testcase name="metabuild_lib_name" classname="metabuild" time="0" />
+    <testcase name="metabuild_json_artifact" classname="metabuild" time="0" />
+    <testcase name="metabuild_metadata" classname="metabuild" time="0" />
+    <testcase name="metabuild_missing_dep" classname="metabuild" time="0" />
+    <testcase name="metabuild_override" classname="metabuild" time="0" />
+    <testcase name="metabuild_links" classname="metabuild" time="0" />
+    <testcase name="cargo_metadata_bad_version" classname="metadata" time="0" />
+    <testcase name="cargo_metadata_no_deps_cwd" classname="metadata" time="0" />
+    <testcase name="cargo_metadata_no_deps_path_to_cargo_toml_absolute" classname="metadata" time="0" />
+    <testcase name="cargo_metadata_no_deps_path_to_cargo_toml_parent_absolute" classname="metadata" time="0" />
+    <testcase name="cargo_metadata_no_deps_path_to_cargo_toml_parent_relative" classname="metadata" time="0" />
+    <testcase name="metabuild_two_versions" classname="metabuild" time="0" />
+    <testcase name="cargo_metadata_no_deps_path_to_cargo_toml_relative" classname="metadata" time="0" />
+    <testcase name="cargo_metadata_simple" classname="metadata" time="0" />
+    <testcase name="cargo_metadata_warns_on_implicit_version" classname="metadata" time="0" />
+    <testcase name="metabuild_optional_dep" classname="metabuild" time="0" />
+    <testcase name="cargo_metadata_with_invalid_manifest" classname="metadata" time="0" />
+    <testcase name="metabuild_workspace" classname="metabuild" time="0" />
+    <testcase name="example" classname="metadata" time="0" />
+    <testcase name="cargo_metadata_path_to_cargo_toml_project" classname="metadata" time="0" />
+    <testcase name="example_lib" classname="metadata" time="0" />
+    <testcase name="library_with_features" classname="metadata" time="0" />
+    <testcase name="library_with_several_crate_types" classname="metadata" time="0" />
+    <testcase name="multiple_features" classname="metadata" time="0" />
+    <testcase name="metadata_links" classname="metadata" time="0" />
+    <testcase name="package_edition_2018" classname="metadata" time="0" />
+    <testcase name="package_metadata" classname="metadata" time="0" />
+    <testcase name="target_edition_2018" classname="metadata" time="0" />
+    <testcase name="workspace_metadata" classname="metadata" time="0" />
+    <testcase name="cargo_metadata_with_deps_and_version" classname="metadata" time="0" />
+    <testcase name="workspace_metadata_no_deps" classname="metadata" time="0" />
+    <testcase name="author_prefers_cargo" classname="new" time="0" />
+    <testcase name="both_lib_and_bin" classname="new" time="0" />
+    <testcase name="rename_dependency" classname="metadata" time="0" />
+    <testcase name="existing" classname="new" time="0" />
+    <testcase name="explicit_invalid_name_not_suggested" classname="new" time="0" />
+    <testcase name="explicit_project_name" classname="new" time="0" />
+    <testcase name="finds_author_email" classname="new" time="0" />
+    <testcase name="finds_author_priority" classname="new" time="0" />
+    <testcase name="finds_author_git" classname="new" time="0" />
+    <testcase name="finds_author_user" classname="new" time="0" />
+    <testcase name="finds_author_user_escaped" classname="new" time="0" />
+    <testcase name="finds_author_username" classname="new" time="0" />
+    <testcase name="finds_git_author" classname="new" time="0" />
+    <testcase name="finds_git_email" classname="new" time="0" />
+    <testcase name="git_prefers_command_line" classname="new" time="0" />
+    <testcase name="invalid_characters" classname="new" time="0" />
+    <testcase name="keyword_name" classname="new" time="0" />
+    <testcase name="new_default_edition" classname="new" time="0" />
+    <testcase name="new_with_bad_edition" classname="new" time="0" />
+    <testcase name="new_with_edition_2015" classname="new" time="0" />
+    <testcase name="finds_local_author_git" classname="new" time="0" />
+    <testcase name="no_argument" classname="new" time="0" />
+    <testcase name="new_with_edition_2018" classname="new" time="0" />
+    <testcase name="reserved_binary_name" classname="new" time="0" />
+    <testcase name="reserved_name" classname="new" time="0" />
+    <testcase name="net_retry_loads_from_config" classname="net_config" time="0" />
+    <testcase name="simple_git" classname="new" time="0" />
+    <testcase name="strip_angle_bracket_author_email" classname="new" time="0" />
+    <testcase name="simple_lib" classname="new" time="0" />
+    <testcase name="simple_bin" classname="new" time="0" />
+    <testcase name="net_retry_git_outputs_warning" classname="net_config" time="0" />
+    <testcase name="subpackage_git_with_gitignore" classname="new" time="0" />
+    <testcase name="subpackage_git_with_vcs_arg" classname="new" time="0" />
+    <testcase name="unknown_flags" classname="new" time="0" />
+    <testcase name="subpackage_no_git" classname="new" time="0" />
+    <testcase name="binary_with_debug" classname="out_dir" time="0" />
+    <testcase name="dynamic_library_with_debug" classname="out_dir" time="0" />
+    <testcase name="include_only_the_binary_from_the_current_package" classname="out_dir" time="0" />
+    <testcase name="avoid_build_scripts" classname="out_dir" time="0" />
+    <testcase name="out_dir_is_a_file" classname="out_dir" time="0" />
+    <testcase name="rlib_with_debug" classname="out_dir" time="0" />
+    <testcase name="static_library_with_debug" classname="out_dir" time="0" />
+    <testcase name="invalid_semver_version" classname="overrides" time="0" />
+    <testcase name="different_version" classname="overrides" time="0" />
+    <testcase name="missing_version" classname="overrides" time="0" />
+    <testcase name="broken_path_override_warns" classname="overrides" time="0" />
+    <testcase name="multiple_specs" classname="overrides" time="0" />
+    <testcase name="replaces_artifacts" classname="out_dir" time="0" />
+    <testcase name="locked_means_locked_yes_no_seriously_i_mean_locked" classname="overrides" time="0" />
+    <testcase name="no_override_self" classname="overrides" time="0" />
+    <testcase name="no_warnings_when_replace_is_used_in_another_workspace_member" classname="overrides" time="0" />
+    <testcase name="override_plus_dep" classname="overrides" time="0" />
+    <testcase name="override_adds_some_deps" classname="overrides" time="0" />
+    <testcase name="override_an_override" classname="overrides" time="0" />
+    <testcase name="override_simple" classname="overrides" time="0" />
+    <testcase name="override_to_path_dep" classname="overrides" time="0" />
+    <testcase name="override_wrong_version" classname="overrides" time="0" />
+    <testcase name="override_with_nothing" classname="overrides" time="0" />
+    <testcase name="override_wrong_name" classname="overrides" time="0" />
+    <testcase name="paths_ok_with_optional" classname="overrides" time="0" />
+    <testcase name="paths_add_optional_bad" classname="overrides" time="0" />
+    <testcase name="overriding_nonexistent_no_spurious" classname="overrides" time="0" />
+    <testcase name="override_with_default_feature" classname="overrides" time="0" />
+    <testcase name="replace_registry_with_path" classname="overrides" time="0" />
+    <testcase name="test_override_dep" classname="overrides" time="0" />
+    <testcase name="persists_across_rebuilds" classname="overrides" time="0" />
+    <testcase name="replace_to_path_dep" classname="overrides" time="0" />
+    <testcase name="do_not_package_if_repository_is_dirty" classname="package" time="0" />
+    <testcase name="update" classname="overrides" time="0" />
+    <testcase name="edition_with_metadata" classname="package" time="0" />
+    <testcase name="transitive" classname="overrides" time="0" />
+    <testcase name="exclude" classname="package" time="0" />
+    <testcase name="use_a_spec_to_select" classname="overrides" time="0" />
+    <testcase name="ignore_workspace_specifier" classname="package" time="0" />
+    <testcase name="do_not_package_if_src_was_modified" classname="package" time="0" />
+    <testcase name="include" classname="package" time="0" />
+    <testcase name="generated_manifest" classname="package" time="0" />
+    <testcase name="lock_file_and_workspace" classname="package" time="0" />
+    <testcase name="ignore_nested" classname="package" time="0" />
+    <testcase name="no_duplicates_from_modified_tracked_files" classname="package" time="0" />
+    <testcase name="no_lock_file_with_library" classname="package" time="0" />
+    <testcase name="package_git_submodule" classname="package" time="0" />
+    <testcase name="package_lockfile_git_repo" classname="package" time="0" />
+    <testcase name="package_lib_with_bin" classname="package" time="0" />
+    <testcase name="metadata_warning" classname="package" time="0" />
+    <testcase name="package_no_default_features" classname="package" time="0" />
+    <testcase name="package_two_kinds_of_deps" classname="package" time="0" />
+    <testcase name="package_lockfile" classname="package" time="0" />
+    <testcase name="package_with_all_features" classname="package" time="0" />
+    <testcase name="package_verbose" classname="package" time="0" />
+    <testcase name="path_dependency_no_version" classname="package" time="0" />
+    <testcase name="package_with_select_features" classname="package" time="0" />
+    <testcase name="package_verification" classname="package" time="0" />
+    <testcase name="test_edition_malformed" classname="package" time="0" />
+    <testcase name="test_edition" classname="package" time="0" />
+    <testcase name="vcs_file_collision" classname="package" time="0" />
+    <testcase name="repackage_on_source_change" classname="package" time="0" />
+    <testcase name="simple" classname="package" time="0" />
+    <testcase name="add_patch" classname="patch" time="0" />
+    <testcase name="add_ignored_patch" classname="patch" time="0" />
+    <testcase name="new_minor" classname="patch" time="0" />
+    <testcase name="non_crates_io" classname="patch" time="0" />
+    <testcase name="no_warn_ws_patch" classname="patch" time="0" />
+    <testcase name="new_major" classname="patch" time="0" />
+    <testcase name="nonexistent" classname="patch" time="0" />
+    <testcase name="patch_depends_on_another_patch" classname="patch" time="0" />
+    <testcase name="patch_git" classname="patch" time="0" />
+    <testcase name="patch_in_virtual" classname="patch" time="0" />
+    <testcase name="patch_to_git" classname="patch" time="0" />
+    <testcase name="remove_patch" classname="patch" time="0" />
+    <testcase name="replace" classname="patch" time="0" />
+    <testcase name="replace_prerelease" classname="patch" time="0" />
+    <testcase name="replace_with_crates_io" classname="patch" time="0" />
+    <testcase name="transitive_new_major" classname="patch" time="0" />
+    <testcase name="transitive_new_minor" classname="patch" time="0" />
+    <testcase name="unused" classname="patch" time="0" />
+    <testcase name="cargo_compile_with_root_dev_deps" classname="path" time="0" />
+    <testcase name="unused_git" classname="patch" time="0" />
+    <testcase name="cargo_compile_with_root_dev_deps_with_testing" classname="path" time="0" />
+    <testcase name="cargo_compile_with_transitive_dev_deps" classname="path" time="0" />
+    <testcase name="error_message_for_missing_manifest" classname="path" time="0" />
+    <testcase name="custom_target_no_rebuild" classname="path" time="0" />
+    <testcase name="missing_path_dependency" classname="path" time="0" />
+    <testcase name="dev_deps_no_rebuild_lib" classname="path" time="0" />
+    <testcase name="invalid_path_dep_in_workspace_with_lockfile" classname="path" time="0" />
+    <testcase name="nested_deps_recompile" classname="path" time="0" />
+    <testcase name="no_rebuild_two_deps" classname="path" time="0" />
+    <testcase name="override_path_dep" classname="path" time="0" />
+    <testcase name="override_and_depend" classname="path" time="0" />
+    <testcase name="no_rebuild_dependency" classname="path" time="0" />
+    <testcase name="override_relative" classname="path" time="0" />
+    <testcase name="override_self" classname="path" time="0" />
+    <testcase name="workspace_produces_rlib" classname="path" time="0" />
+    <testcase name="deep_dependencies_trigger_rebuild" classname="path" time="0" />
+    <testcase name="path_dep_build_cmd" classname="path" time="0" />
+    <testcase name="panic_abort_plugins" classname="plugins" time="0" />
+    <testcase name="native_plugin_dependency_with_custom_ar_linker" classname="plugins" time="0" />
+    <testcase name="plugin_to_the_max" classname="plugins" time="0" />
+    <testcase name="plugin_with_dynamic_native_dependency" classname="plugins" time="0" />
+    <testcase name="shared_panic_abort_plugins" classname="plugins" time="0" />
+    <testcase name="doctest_a_plugin" classname="plugins" time="0" />
+    <testcase name="plugin_integration" classname="plugins" time="0" />
+    <testcase name="plugin_and_proc_macro" classname="proc_macro" time="0" />
+    <testcase name="thin_lto_works" classname="path" time="0" />
+    <testcase name="noop" classname="proc_macro" time="0" />
+    <testcase name="proc_macro_crate_type_multiple" classname="proc_macro" time="0" />
+    <testcase name="impl_and_derive" classname="proc_macro" time="0" />
+    <testcase name="proc_macro_crate_type_warning" classname="proc_macro" time="0" />
+    <testcase name="probe_cfg_before_crate_type_discovery" classname="proc_macro" time="0" />
+    <testcase name="proc_macro_crate_type_warning_plugin" classname="proc_macro" time="0" />
+    <testcase name="profile_config_error_paths" classname="profile_config" time="0" />
+    <testcase name="profile_config_all_options" classname="profile_config" time="0" />
+    <testcase name="profile_config_gated" classname="profile_config" time="0" />
+    <testcase name="profile_config_mixed_types" classname="profile_config" time="0" />
+    <testcase name="profile_config_no_warn_unknown_override" classname="profile_config" time="0" />
+    <testcase name="profile_config_override_spec_multiple" classname="profile_config" time="0" />
+    <testcase name="profile_config_syntax_errors" classname="profile_config" time="0" />
+    <testcase name="profile_config_validate_errors" classname="profile_config" time="0" />
+    <testcase name="profile_config_override_precedence" classname="profile_config" time="0" />
+    <testcase name="proc_macro_doctest" classname="proc_macro" time="0" />
+    <testcase name="profile_config_validate_warnings" classname="profile_config" time="0" />
+    <testcase name="proc_macro_crate_type" classname="proc_macro" time="0" />
+    <testcase name="profile_override_dev_release_only" classname="profile_overrides" time="0" />
+    <testcase name="profile_override_bad_settings" classname="profile_overrides" time="0" />
+    <testcase name="profile_override_gated" classname="profile_overrides" time="0" />
+    <testcase name="profile_override_spec_multiple" classname="profile_overrides" time="0" />
+    <testcase name="profile_override_basic" classname="profile_overrides" time="0" />
+    <testcase name="profile_override_spec" classname="profile_overrides" time="0" />
+    <testcase name="profile_override_warnings" classname="profile_overrides" time="0" />
+    <testcase name="profile_override_hierarchy" classname="profile_overrides" time="0" />
+    <testcase name="profile_selection_build" classname="profile_targets" time="0" />
+    <testcase name="profile_selection_build_all_targets" classname="profile_targets" time="0" />
+    <testcase name="profile_selection_check_all_targets" classname="profile_targets" time="0" />
+    <testcase name="profile_selection_check_all_targets_release" classname="profile_targets" time="0" />
+    <testcase name="profile_selection_bench" classname="profile_targets" time="0" />
+    <testcase name="profile_selection_check_all_targets_test" classname="profile_targets" time="0" />
+    <testcase name="profile_selection_build_all_targets_release" classname="profile_targets" time="0" />
+    <testcase name="profile_selection_build_release" classname="profile_targets" time="0" />
+    <testcase name="debug_override_1" classname="profiles" time="0" />
+    <testcase name="opt_level_override_0" classname="profiles" time="0" />
+    <testcase name="opt_level_overrides" classname="profiles" time="0" />
+    <testcase name="profile_doc_deprecated" classname="profiles" time="0" />
+    <testcase name="profile_selection_test" classname="profile_targets" time="0" />
+    <testcase name="profile_selection_test_release" classname="profile_targets" time="0" />
+    <testcase name="profile_in_non_root_manifest_triggers_a_warning" classname="profiles" time="0" />
+    <testcase name="profile_in_virtual_manifest_works" classname="profiles" time="0" />
+    <testcase name="profile_overrides" classname="profiles" time="0" />
+    <testcase name="profile_panic_test_bench" classname="profiles" time="0" />
+    <testcase name="block_publish_feature_not_enabled" classname="publish" time="0" />
+    <testcase name="profile_selection_doc" classname="profile_targets" time="0" />
+    <testcase name="block_publish_no_registry" classname="publish" time="0" />
+    <testcase name="top_level_overrides_deps" classname="profiles" time="0" />
+    <testcase name="dont_publish_dirty" classname="publish" time="0" />
+    <testcase name="git_deps" classname="publish" time="0" />
+    <testcase name="new_crate_rejected" classname="publish" time="0" />
+    <testcase name="old_token_location" classname="publish" time="0" />
+    <testcase name="dry_run" classname="publish" time="0" />
+    <testcase name="ignore_when_crate_ignored" classname="publish" time="0" />
+    <testcase name="path_dependency_no_version" classname="publish" time="0" />
+    <testcase name="publish_empty_list" classname="publish" time="0" />
+    <testcase name="publish_allowed_registry" classname="publish" time="0" />
+    <testcase name="publish_clean" classname="publish" time="0" />
+    <testcase name="publish_in_sub_repo" classname="publish" time="0" />
+    <testcase name="publish_when_ignored" classname="publish" time="0" />
+    <testcase name="publish_with_all_features" classname="publish" time="0" />
+    <testcase name="publish_with_no_default_features" classname="publish" time="0" />
+    <testcase name="registry_not_in_publish_list" classname="publish" time="0" />
+    <testcase name="simple" classname="publish" time="0" />
+    <testcase name="simple_with_host" classname="publish" time="0" />
+    <testcase name="simple_with_index_and_host" classname="publish" time="0" />
+    <testcase name="cargo_read_manifest_cwd" classname="read_manifest" time="0" />
+    <testcase name="publish_with_select_features" classname="publish" time="0" />
+    <testcase name="unpublishable_crate" classname="publish" time="0" />
+    <testcase name="cargo_read_manifest_path_to_cargo_toml_absolute" classname="read_manifest" time="0" />
+    <testcase name="publish_with_patch" classname="publish" time="0" />
+    <testcase name="cargo_read_manifest_path_to_cargo_toml_parent_relative" classname="read_manifest" time="0" />
+    <testcase name="cargo_read_manifest_path_to_cargo_toml_parent_absolute" classname="read_manifest" time="0" />
+    <testcase name="cargo_read_manifest_path_to_cargo_toml_relative" classname="read_manifest" time="0" />
+    <testcase name="bad_cksum" classname="registry" time="0" />
+    <testcase name="bad_and_or_malicious_packages_rejected" classname="registry" time="0" />
+    <testcase name="bad_license_file" classname="registry" time="0" />
+    <testcase name="add_dep_dont_update_registry" classname="registry" time="0" />
+    <testcase name="bundled_crate_in_registry" classname="registry" time="0" />
+    <testcase name="disallow_network" classname="registry" time="0" />
+    <testcase name="bump_version_dont_update_registry" classname="registry" time="0" />
+    <testcase name="deps" classname="registry" time="0" />
+    <testcase name="fetch_downloads" classname="registry" time="0" />
+    <testcase name="dev_dependency_not_used" classname="registry" time="0" />
+    <testcase name="git_and_registry_dep" classname="registry" time="0" />
+    <testcase name="lockfile_locks" classname="registry" time="0" />
+    <testcase name="git_init_templatedir_missing" classname="registry" time="0" />
+    <testcase name="login_with_no_cargo_dir" classname="registry" time="0" />
+    <testcase name="login_with_differently_sized_token" classname="registry" time="0" />
+    <testcase name="mis_hyphenated" classname="registry" time="0" />
+    <testcase name="lockfile_locks_transitively" classname="registry" time="0" />
+    <testcase name="nonexistent" classname="registry" time="0" />
+    <testcase name="old_version_req" classname="registry" time="0" />
+    <testcase name="old_version_req_upstream" classname="registry" time="0" />
+    <testcase name="only_download_relevant" classname="registry" time="0" />
+    <testcase name="package_with_path_deps" classname="registry" time="0" />
+    <testcase name="relying_on_a_yank_is_bad" classname="registry" time="0" />
+    <testcase name="resolve_and_backtracking" classname="registry" time="0" />
+    <testcase name="toml_lies_but_index_is_truth" classname="registry" time="0" />
+    <testcase name="update_backtracking_ok" classname="registry" time="0" />
+    <testcase name="simple" classname="registry" time="0" />
+    <testcase name="update_offline" classname="registry" time="0" />
+    <testcase name="rename_deps_and_features" classname="registry" time="0" />
+    <testcase name="update_registry" classname="registry" time="0" />
+    <testcase name="update_multiple_packages" classname="registry" time="0" />
+    <testcase name="update_same_prefix_oh_my_how_was_this_a_bug" classname="registry" time="0" />
+    <testcase name="update_lockfile" classname="registry" time="0" />
+    <testcase name="update_publish_then_update" classname="registry" time="0" />
+    <testcase name="update_with_lockfile_if_packages_missing" classname="registry" time="0" />
+    <testcase name="update_transitive_dependency" classname="registry" time="0" />
+    <testcase name="upstream_warnings_on_extra_verbose" classname="registry" time="0" />
+    <testcase name="updating_a_dep" classname="registry" time="0" />
+    <testcase name="wrong_case" classname="registry" time="0" />
+    <testcase name="use_semver" classname="registry" time="0" />
+    <testcase name="vv_prints_warnings" classname="registry" time="0" />
+    <testcase name="wrong_version" classname="registry" time="0" />
+    <testcase name="features_not_working" classname="rename_deps" time="0" />
+    <testcase name="yanks_are_not_used" classname="registry" time="0" />
+    <testcase name="yanks_in_lockfiles_are_ok" classname="registry" time="0" />
+    <testcase name="can_run_doc_tests" classname="rename_deps" time="0" />
+    <testcase name="features_still_work" classname="rename_deps" time="0" />
+    <testcase name="rename_and_patch" classname="rename_deps" time="0" />
+    <testcase name="rename_affects_fingerprint" classname="rename_deps" time="0" />
+    <testcase name="lots_of_names" classname="rename_deps" time="0" />
+    <testcase name="rename_dependency" classname="rename_deps" time="0" />
+    <testcase name="bench_arg_features" classname="required_features" time="0" />
+    <testcase name="rename_twice" classname="rename_deps" time="0" />
+    <testcase name="bench_default_features" classname="required_features" time="0" />
+    <testcase name="rename_with_dash" classname="rename_deps" time="0" />
+    <testcase name="bench_multiple_required_features" classname="required_features" time="0" />
+    <testcase name="rename_with_different_names" classname="rename_deps" time="0" />
+    <testcase name="build_bin_arg_features" classname="required_features" time="0" />
+    <testcase name="build_example_arg_features" classname="required_features" time="0" />
+    <testcase name="build_bin_default_features" classname="required_features" time="0" />
+    <testcase name="build_bin_multiple_required_features" classname="required_features" time="0" />
+    <testcase name="build_example_default_features" classname="required_features" time="0" />
+    <testcase name="install_arg_features" classname="required_features" time="0" />
+    <testcase name="build_example_multiple_required_features" classname="required_features" time="0" />
+    <testcase name="install_multiple_required_features" classname="required_features" time="0" />
+    <testcase name="dep_feature_in_toml" classname="required_features" time="0" />
+    <testcase name="run_default_multiple_required_features" classname="required_features" time="0" />
+    <testcase name="install_default_features" classname="required_features" time="0" />
+    <testcase name="dep_feature_in_cmd_line" classname="required_features" time="0" />
+    <testcase name="run_default" classname="required_features" time="0" />
+    <testcase name="test_arg_features" classname="required_features" time="0" />
+    <testcase name="conflict_store_bug" classname="resolve" time="0" />
+    <testcase name="hard_equality" classname="resolve" time="0" />
+    <testcase name="incomplete_information_skiping" classname="resolve" time="0" />
+    <testcase name="incomplete_information_skiping_2" classname="resolve" time="0" />
+    <testcase name="incomplete_information_skiping_3" classname="resolve" time="0" />
+    <testcase name="test_default_features" classname="required_features" time="0" />
+    <testcase name="test_multiple_required_features" classname="required_features" time="0" />
+    <testcase name="test_skips_compiling_bin_with_missing_required_features" classname="required_features" time="0" />
+    <testcase name="minimal_version_cli" classname="resolve" time="0" />
+    <testcase name="large_conflict_cache" classname="resolve" time="0" />
+    <testcase name="limited_independence_of_irrelevant_alternatives" classname="resolve" time="0" />
+    <testcase name="resolving_allows_multiple_compatible_versions" classname="resolve" time="0" />
+    <testcase name="resolving_backtrack" classname="resolve" time="0" />
+    <testcase name="resolving_backtrack_features" classname="resolve" time="0" />
+    <testcase name="resolving_but_no_exists" classname="resolve" time="0" />
+    <testcase name="resolving_cycle" classname="resolve" time="0" />
+    <testcase name="resolving_incompat_versions" classname="resolve" time="0" />
+    <testcase name="resolving_mis_hyphenated_from_registry" classname="resolve" time="0" />
+    <testcase name="passes_validation" classname="resolve" time="0" />
+    <testcase name="resolving_with_constrained_sibling_backtrack_activation" classname="resolve" time="0" />
+    <testcase name="resolving_with_constrained_sibling_backtrack_parent" classname="resolve" time="0" />
+    <testcase name="resolving_with_constrained_sibling_transitive_dep_effects" classname="resolve" time="0" />
+    <testcase name="resolving_with_deep_backtracking" classname="resolve" time="0" />
+    <testcase name="resolving_with_deep_traps" classname="resolve" time="0" />
+    <testcase name="minimum_version_errors_the_same" classname="resolve" time="0" />
+    <testcase name="resolving_with_many_versions" classname="resolve" time="0" />
+    <testcase name="resolving_with_specific_version" classname="resolve" time="0" />
+    <testcase name="resolving_with_sys_crates" classname="resolve" time="0" />
+    <testcase name="resolving_wrong_case_from_registry" classname="resolve" time="0" />
+    <testcase name="test_dependency_with_empty_name" classname="resolve" time="0" />
+    <testcase name="test_resolving_common_transitive_deps" classname="resolve" time="0" />
+    <testcase name="test_resolving_empty_dependency_list" classname="resolve" time="0" />
+    <testcase name="test_resolving_maximum_version_with_transitive_deps" classname="resolve" time="0" />
+    <testcase name="test_resolving_minimum_version_with_transitive_deps" classname="resolve" time="0" />
+    <testcase name="test_resolving_multiple_deps" classname="resolve" time="0" />
+    <testcase name="test_resolving_one_dep" classname="resolve" time="0" />
+    <testcase name="test_resolving_only_package" classname="resolve" time="0" />
+    <testcase name="test_resolving_transitive_deps" classname="resolve" time="0" />
+    <testcase name="test_resolving_with_dev_deps" classname="resolve" time="0" />
+    <testcase name="test_resolving_with_same_name" classname="resolve" time="0" />
+    <testcase name="autobins_disables" classname="run" time="0" />
+    <testcase name="bogus_default_run" classname="run" time="0" />
+    <testcase name="resolving_with_constrained_cousins_backtrack" classname="resolve" time="0" />
+    <testcase name="default_run_unstable" classname="run" time="0" />
+    <testcase name="default_run_workspace" classname="run" time="0" />
+    <testcase name="dashes_are_forwarded" classname="run" time="0" />
+    <testcase name="either_name_or_example" classname="run" time="0" />
+    <testcase name="removing_a_dep_cant_brake" classname="resolve" time="0" />
+    <testcase name="exit_code" classname="run" time="0" />
+    <testcase name="exit_code_verbose" classname="run" time="0" />
+    <testcase name="example_with_release_flag" classname="run" time="0" />
+    <testcase name="explicit_bin_with_args" classname="run" time="0" />
+    <testcase name="no_main_file" classname="run" time="0" />
+    <testcase name="fail_no_extra_verbose" classname="run" time="0" />
+    <testcase name="one_bin_multiple_examples" classname="run" time="0" />
+    <testcase name="quiet_and_verbose_config" classname="run" time="0" />
+    <testcase name="library_paths_sorted_alphabetically" classname="run" time="0" />
+    <testcase name="release_works" classname="run" time="0" />
+    <testcase name="run_bins" classname="run" time="0" />
+    <testcase name="run_bin_different_name" classname="run" time="0" />
+    <testcase name="run_bin_example" classname="run" time="0" />
+    <testcase name="run_example_autodiscover_2015" classname="run" time="0" />
+    <testcase name="run_example_autodiscover_2015_with_autoexamples_disabled" classname="run" time="0" />
+    <testcase name="run_example_autodiscover_2015_with_autoexamples_enabled" classname="run" time="0" />
+    <testcase name="run_example_autodiscover_2018" classname="run" time="0" />
+    <testcase name="run_example" classname="run" time="0" />
+    <testcase name="run_library_example" classname="run" time="0" />
+    <testcase name="run_dylib_dep" classname="run" time="0" />
+    <testcase name="run_with_filename" classname="run" time="0" />
+    <testcase name="run_from_executable_folder" classname="run" time="0" />
+    <testcase name="run_workspace" classname="run" time="0" />
+    <testcase name="run_with_library_paths" classname="run" time="0" />
+    <testcase name="run_multiple_packages" classname="run" time="0" />
+    <testcase name="simple_quiet_and_verbose" classname="run" time="0" />
+    <testcase name="simple" classname="run" time="0" />
+    <testcase name="simple_quiet" classname="run" time="0" />
+    <testcase name="simple_with_args" classname="run" time="0" />
+    <testcase name="too_many_bins" classname="run" time="0" />
+    <testcase name="specify_default_run" classname="run" time="0" />
+    <testcase name="build_foo_with_bar_dependency" classname="rustc" time="0" />
+    <testcase name="specify_name" classname="run" time="0" />
+    <testcase name="build_lib_for_foo" classname="rustc" time="0" />
+    <testcase name="build_only_bar_dependency" classname="rustc" time="0" />
+    <testcase name="build_main_and_allow_unstable_options" classname="rustc" time="0" />
+    <testcase name="fail_with_multiple_packages" classname="rustc" time="0" />
+    <testcase name="fails_when_trying_to_build_main_and_lib_with_args" classname="rustc" time="0" />
+    <testcase name="fails_with_args_to_all_binaries" classname="rustc" time="0" />
+    <testcase name="build_with_args_to_one_of_multiple_binaries" classname="rustc" time="0" />
+    <testcase name="build_with_args_to_one_of_multiple_tests" classname="rustc" time="0" />
+    <testcase name="lib" classname="rustc" time="0" />
+    <testcase name="rustc_fingerprint" classname="rustc" time="0" />
+    <testcase name="rustc_test_with_implicit_bin" classname="rustc" time="0" />
+    <testcase name="rustc_with_other_profile" classname="rustc" time="0" />
+    <testcase name="targets_selected_all" classname="rustc" time="0" />
+    <testcase name="targets_selected_default" classname="rustc" time="0" />
+    <testcase name="features" classname="rustdoc" time="0" />
+    <testcase name="rustdoc_args" classname="rustdoc" time="0" />
+    <testcase name="rustc_info_cache" classname="rustc_info_cache" time="0" />
+    <testcase name="rustdoc_foo_with_bar_dependency" classname="rustdoc" time="0" />
+    <testcase name="rustdoc_only_bar_dependency" classname="rustdoc" time="0" />
+    <testcase name="rustdoc_same_name_documents_lib" classname="rustdoc" time="0" />
+    <testcase name="bad_flags" classname="rustdocflags" time="0" />
+    <testcase name="rustdoc_simple" classname="rustdoc" time="0" />
+    <testcase name="parses_config" classname="rustdocflags" time="0" />
+    <testcase name="parses_env" classname="rustdocflags" time="0" />
+    <testcase name="resolving_with_many_equivalent_backtracking" classname="resolve" time="0" />
+    <testcase name="rustdocflags_passed_to_rustdoc_through_cargo_test_only_once" classname="rustdocflags" time="0" />
+    <testcase name="build_rustflags_build_script" classname="rustflags" time="0" />
+    <testcase name="rustdocflags_passed_to_rustdoc_through_cargo_test" classname="rustdocflags" time="0" />
+    <testcase name="build_rustflags_build_script_dep" classname="rustflags" time="0" />
+    <testcase name="build_rustflags_build_script_dep_with_target" classname="rustflags" time="0" />
+    <testcase name="build_rustflags_no_recompile" classname="rustflags" time="0" />
+    <testcase name="build_rustflags_build_script_with_target" classname="rustflags" time="0" />
+    <testcase name="build_rustflags_plugin" classname="rustflags" time="0" />
+    <testcase name="build_rustflags_plugin_dep" classname="rustflags" time="0" />
+    <testcase name="build_rustflags_normal_source" classname="rustflags" time="0" />
+    <testcase name="rerun" classname="rustdocflags" time="0" />
+    <testcase name="build_rustflags_plugin_with_target" classname="rustflags" time="0" />
+    <testcase name="build_rustflags_normal_source_with_target" classname="rustflags" time="0" />
+    <testcase name="build_rustflags_plugin_dep_with_target" classname="rustflags" time="0" />
+    <testcase name="build_rustflags_recompile" classname="rustflags" time="0" />
+    <testcase name="build_rustflags_with_home_config" classname="rustflags" time="0" />
+    <testcase name="build_rustflags_recompile2" classname="rustflags" time="0" />
+    <testcase name="env_rustflags_build_script" classname="rustflags" time="0" />
+    <testcase name="env_rustflags_build_script_dep" classname="rustflags" time="0" />
+    <testcase name="cfg_rustflags_normal_source" classname="rustflags" time="0" />
+    <testcase name="env_rustflags_build_script_dep_with_target" classname="rustflags" time="0" />
+    <testcase name="env_rustflags_build_script_with_target" classname="rustflags" time="0" />
+    <testcase name="cfg_rustflags_precedence" classname="rustflags" time="0" />
+    <testcase name="env_rustflags_no_recompile" classname="rustflags" time="0" />
+    <testcase name="env_rustflags_plugin" classname="rustflags" time="0" />
+    <testcase name="env_rustflags_plugin_dep" classname="rustflags" time="0" />
+    <testcase name="env_rustflags_plugin_dep_with_target" classname="rustflags" time="0" />
+    <testcase name="env_rustflags_normal_source" classname="rustflags" time="0" />
+    <testcase name="env_rustflags_plugin_with_target" classname="rustflags" time="0" />
+    <testcase name="env_rustflags_normal_source_with_target" classname="rustflags" time="0" />
+    <testcase name="env_rustflags_recompile" classname="rustflags" time="0" />
+    <testcase name="env_rustflags_recompile2" classname="rustflags" time="0" />
+    <testcase name="target_rustflags_string_and_array_form1" classname="rustflags" time="0" />
+    <testcase name="target_rustflags_string_and_array_form2" classname="rustflags" time="0" />
+    <testcase name="help" classname="search" time="0" />
+    <testcase name="target_rustflags_normal_source" classname="rustflags" time="0" />
+    <testcase name="multiple_query_params" classname="search" time="0" />
+    <testcase name="target_rustflags_precedence" classname="rustflags" time="0" />
+    <testcase name="not_update" classname="search" time="0" />
+    <testcase name="replace_default" classname="search" time="0" />
+    <testcase name="two_matching_in_config" classname="rustflags" time="0" />
+    <testcase name="simple" classname="search" time="0" />
+    <testcase name="simple_with_index_and_host" classname="search" time="0" />
+    <testcase name="lines_match_works" classname="support" time="0" />
+    <testcase name="meta_test_deep_pretty_print_registry" classname="support::resolver" time="0" />
+    <testcase name="simple_with_host" classname="search" time="0" />
+    <testcase name="features_are_quoted" classname="shell_quoting" time="0" />
+    <testcase name="almost_cyclic_but_not_quite" classname="test" time="0" />
+    <testcase name="meta_test_deep_trees_from_strategy" classname="support::resolver" time="0" />
+    <testcase name="bench_without_name" classname="test" time="0" />
+    <testcase name="bad_example" classname="test" time="0" />
+    <testcase name="bin_is_preserved" classname="test" time="0" />
+    <testcase name="bin_does_not_rebuild_tests" classname="test" time="0" />
+    <testcase name="bin_without_name" classname="test" time="0" />
+    <testcase name="meta_test_multiple_versions_strategy" classname="support::resolver" time="0" />
+    <testcase name="bin_there_for_integration" classname="test" time="0" />
+    <testcase name="use_git_gc" classname="small_fd_limits" time="0" />
+    <testcase name="cargo_test_env" classname="test" time="0" />
+    <testcase name="build_then_selective_test" classname="test" time="0" />
+    <testcase name="cargo_test_failing_test_in_lib" classname="test" time="0" />
+    <testcase name="cargo_test_overflow_checks" classname="test" time="0" />
+    <testcase name="cargo_test_failing_test_in_bin" classname="test" time="0" />
+    <testcase name="can_not_mix_doc_tests_and_regular_tests" classname="test" time="0" />
+    <testcase name="cargo_test_failing_test_in_test" classname="test" time="0" />
+    <testcase name="cargo_test_simple" classname="test" time="0" />
+    <testcase name="cargo_test_release" classname="test" time="0" />
+    <testcase name="cargo_test_verbose" classname="test" time="0" />
+    <testcase name="cargo_test_twice" classname="test" time="0" />
+    <testcase name="cfg_test_even_with_no_harness" classname="test" time="0" />
+    <testcase name="cyclic_dev" classname="test" time="0" />
+    <testcase name="dashes_to_underscores" classname="test" time="0" />
+    <testcase name="dev_dep_with_build_script" classname="test" time="0" />
+    <testcase name="cyclic_dev_dep_doc_test" classname="test" time="0" />
+    <testcase name="doctest_only_with_dev_dep" classname="test" time="0" />
+    <testcase name="doctest_dev_dep" classname="test" time="0" />
+    <testcase name="doctest_feature" classname="test" time="0" />
+    <testcase name="doctest_and_registry" classname="test" time="0" />
+    <testcase name="dylib_doctest2" classname="test" time="0" />
+    <testcase name="doctest_skip_staticlib" classname="test" time="0" />
+    <testcase name="dont_run_examples" classname="test" time="0" />
+    <testcase name="dylib_doctest" classname="test" time="0" />
+    <testcase name="example_without_name" classname="test" time="0" />
+    <testcase name="example_bin_same_name" classname="test" time="0" />
+    <testcase name="example_with_dev_dep" classname="test" time="0" />
+    <testcase name="example_dev_dep" classname="test" time="0" />
+    <testcase name="external_test_explicit" classname="test" time="0" />
+    <testcase name="external_test_implicit" classname="test" time="0" />
+    <testcase name="external_test_named_test" classname="test" time="0" />
+    <testcase name="filter_no_doc_tests" classname="test" time="0" />
+    <testcase name="json_artifact_includes_executable_for_integration_tests" classname="test" time="0" />
+    <testcase name="json_artifact_includes_executable_for_library_tests" classname="test" time="0" />
+    <testcase name="json_artifact_includes_test_flag" classname="test" time="0" />
+    <testcase name="lib_bin_same_name" classname="test" time="0" />
+    <testcase name="lib_with_standard_name2" classname="test" time="0" />
+    <testcase name="find_dependency_of_proc_macro_dependency_with_target" classname="test" time="0" />
+    <testcase name="lib_with_standard_name" classname="test" time="0" />
+    <testcase name="lib_without_name" classname="test" time="0" />
+    <testcase name="many_similar_names" classname="test" time="0" />
+    <testcase name="only_test_docs" classname="test" time="0" />
+    <testcase name="no_fail_fast" classname="test" time="0" />
+    <testcase name="panic_abort_multiple" classname="test" time="0" />
+    <testcase name="selective_test_optional_dep" classname="test" time="0" />
+    <testcase name="pass_correct_cfgs_flags_to_rustdoc" classname="test" time="0" />
+    <testcase name="pass_through_command_line" classname="test" time="0" />
+    <testcase name="selective_test_wonky_profile" classname="test" time="0" />
+    <testcase name="publish_a_crate_without_tests" classname="test" time="0" />
+    <testcase name="selective_testing_with_docs" classname="test" time="0" />
+    <testcase name="test_all_exclude" classname="test" time="0" />
+    <testcase name="test_all_targets_lib" classname="test" time="0" />
+    <testcase name="selective_testing" classname="test" time="0" />
+    <testcase name="test_all_member_dependency_same_name" classname="test" time="0" />
+    <testcase name="test_dep_with_dev" classname="test" time="0" />
+    <testcase name="test_all_virtual_manifest" classname="test" time="0" />
+    <testcase name="test_all_workspace" classname="test" time="0" />
+    <testcase name="test_build_script_links" classname="test" time="0" />
+    <testcase name="test_hint_workspace" classname="test" time="0" />
+    <testcase name="test_dylib" classname="test" time="0" />
+    <testcase name="test_hint_not_masked_by_doctest" classname="test" time="0" />
+    <testcase name="test_many_targets" classname="test" time="0" />
+    <testcase name="test_many_with_features" classname="test" time="0" />
+    <testcase name="test_multiple_packages" classname="test" time="0" />
+    <testcase name="test_no_harness" classname="test" time="0" />
+    <testcase name="test_no_run" classname="test" time="0" />
+    <testcase name="test_panic_abort_with_dep" classname="test" time="0" />
+    <testcase name="test_order" classname="test" time="0" />
+    <testcase name="test_run_implicit_bench_target" classname="test" time="0" />
+    <testcase name="test_run_implicit_bin_target" classname="test" time="0" />
+    <testcase name="test_release_ignore_panic" classname="test" time="0" />
+    <testcase name="test_run_specific_bin_target" classname="test" time="0" />
+    <testcase name="test_run_implicit_test_target" classname="test" time="0" />
+    <testcase name="test_run_specific_test_target" classname="test" time="0" />
+    <testcase name="test_then_build" classname="test" time="0" />
+    <testcase name="test_virtual_manifest_all_implied" classname="test" time="0" />
+    <testcase name="test_run_implicit_example_target" classname="test" time="0" />
+    <testcase name="test_twice_with_build_cmd" classname="test" time="0" />
+    <testcase name="test_without_name" classname="test" time="0" />
+    <testcase name="test_with_example_twice" classname="test" time="0" />
+    <testcase name="absolute_tools" classname="tool_paths" time="0" />
+    <testcase name="test_with_deep_lib_dep" classname="test" time="0" />
+    <testcase name="custom_runner_cfg_collision" classname="tool_paths" time="0" />
+    <testcase name="custom_runner_cfg" classname="tool_paths" time="0" />
+    <testcase name="test_with_lib_dep" classname="test" time="0" />
+    <testcase name="pathless_tools" classname="tool_paths" time="0" />
+    <testcase name="custom_runner_cfg_precedence" classname="tool_paths" time="0" />
+    <testcase name="relative_tools" classname="tool_paths" time="0" />
+    <testcase name="custom_runner" classname="tool_paths" time="0" />
+    <testcase name="change_package_version" classname="update" time="0" />
+    <testcase name="add_dep_deep_new_requirement" classname="update" time="0" />
+    <testcase name="conservative" classname="update" time="0" />
+    <testcase name="preserve_top_comment" classname="update" time="0" />
+    <testcase name="dry_run_update" classname="update" time="0" />
+    <testcase name="everything_real_deep" classname="update" time="0" />
+    <testcase name="minor_update_two_places" classname="update" time="0" />
+    <testcase name="update_precise" classname="update" time="0" />
+    <testcase name="transitive_minor_update" classname="update" time="0" />
+    <testcase name="cargo_verify_project_cwd" classname="verify_project" time="0" />
+    <testcase name="cargo_verify_project_path_to_cargo_toml_absolute" classname="verify_project" time="0" />
+    <testcase name="cargo_verify_project_honours_unstable_features" classname="verify_project" time="0" />
+    <testcase name="cargo_verify_project_path_to_cargo_toml_relative" classname="verify_project" time="0" />
+    <testcase name="version_works_with_bad_config" classname="version" time="0" />
+    <testcase name="version_works_with_bad_target_dir" classname="version" time="0" />
+    <testcase name="simple" classname="version" time="0" />
+    <testcase name="update_via_new_dep" classname="update" time="0" />
+    <testcase name="update_via_new_member" classname="update" time="0" />
+    <testcase name="no_warning_on_bin_failure" classname="warn_on_failure" time="0" />
+    <testcase name="warning_on_lib_failure" classname="warn_on_failure" time="0" />
+    <testcase name="cycle" classname="workspaces" time="0" />
+    <testcase name="dangling_member" classname="workspaces" time="0" />
+    <testcase name="no_warning_on_success" classname="warn_on_failure" time="0" />
+    <testcase name="cargo_home_at_root_works" classname="workspaces" time="0" />
+    <testcase name="bare_workspace_ok" classname="workspaces" time="0" />
+    <testcase name="error_if_parent_cargo_toml_is_invalid" classname="workspaces" time="0" />
+    <testcase name="dont_recurse_out_of_cargo_home" classname="workspaces" time="0" />
+    <testcase name="exclude_members_preferred" classname="workspaces" time="0" />
+    <testcase name="dep_used_with_separate_features" classname="workspaces" time="0" />
+    <testcase name="exclude_but_also_depend" classname="workspaces" time="0" />
+    <testcase name="explicit_package_argument_works_with_virtual_manifest" classname="workspaces" time="0" />
+    <testcase name="glob_syntax_invalid_members" classname="workspaces" time="0" />
+    <testcase name="excluded_simple" classname="workspaces" time="0" />
+    <testcase name="include_virtual" classname="workspaces" time="0" />
+    <testcase name="fetch_fetches_all" classname="workspaces" time="0" />
+    <testcase name="invalid_members" classname="workspaces" time="0" />
+    <testcase name="invalid_parent_pointer" classname="workspaces" time="0" />
+    <testcase name="inferred_root" classname="workspaces" time="0" />
+    <testcase name="inferred_path_dep" classname="workspaces" time="0" />
+    <testcase name="lock_doesnt_change_depending_on_crate" classname="workspaces" time="0" />
+    <testcase name="glob_syntax" classname="workspaces" time="0" />
+    <testcase name="new_warns_you_this_will_not_work" classname="workspaces" time="0" />
+    <testcase name="lockfile_can_specify_nonexistant_members" classname="workspaces" time="0" />
+    <testcase name="parent_doesnt_point_to_child" classname="workspaces" time="0" />
+    <testcase name="path_dep_outside_workspace_is_not_member" classname="workspaces" time="0" />
+    <testcase name="members_include_path_deps" classname="workspaces" time="0" />
+    <testcase name="lock_works_for_everyone" classname="workspaces" time="0" />
+    <testcase name="parent_pointer_works" classname="workspaces" time="0" />
+    <testcase name="relative_path_for_root_works" classname="workspaces" time="0" />
+    <testcase name="same_names_in_workspace" classname="workspaces" time="0" />
+    <testcase name="relative_path_for_member_works" classname="workspaces" time="0" />
+    <testcase name="rebuild_please" classname="workspaces" time="0" />
+    <testcase name="simple_explicit" classname="workspaces" time="0" />
+    <testcase name="relative_rustc" classname="workspaces" time="0" />
+    <testcase name="share_dependencies" classname="workspaces" time="0" />
+    <testcase name="simple_explicit_default_members" classname="workspaces" time="0" />
+    <testcase name="two_roots" classname="workspaces" time="0" />
+    <testcase name="test_path_dependency_under_member" classname="workspaces" time="0" />
+    <testcase name="virtual_build_no_members" classname="workspaces" time="0" />
+    <testcase name="virtual_default_member_is_not_a_member" classname="workspaces" time="0" />
+    <testcase name="virtual_build_all_implied" classname="workspaces" time="0" />
+    <testcase name="test_in_and_out_of_workspace" classname="workspaces" time="0" />
+    <testcase name="virtual_misconfigure" classname="workspaces" time="0" />
+    <testcase name="virtual_default_members" classname="workspaces" time="0" />
+    <testcase name="workspace_isnt_root" classname="workspaces" time="0" />
+    <testcase name="transitive_path_dep" classname="workspaces" time="0" />
+    <testcase name="virtual_works" classname="workspaces" time="0" />
+    <testcase name="ws_rustc_err" classname="workspaces" time="0" />
+    <testcase name="workspace_in_git" classname="workspaces" time="0" />
+    <testcase name="ws_err_unused" classname="workspaces" time="0" />
+    <testcase name="you_cannot_generate_lockfile_for_empty_workspaces" classname="workspaces" time="0" />
+    <testcase name="ws_warn_path" classname="workspaces" time="0" />
+    <testcase name="workspace_with_transitive_dev_deps" classname="workspaces" time="0" />
+    <testcase name="ws_warn_unused" classname="workspaces" time="0" />
   </testsuite>
 </testsuites>

--- a/src/expected_outputs/failed.json.out
+++ b/src/expected_outputs/failed.json.out
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
   <testsuite id="0" name="cargo test #0" package="testsuite/cargo test #0" tests="2" errors="0" failures="1" hostname="localhost" timestamp="2020-06-15T20:58:06.406283700+00:00" time="0">
-    <testcase name="tests::fails" time="0">
+    <testcase name="fails" classname="tests" time="0">
       <failure type="cargo test" message="thread &apos;tests::fails&apos; panicked at &apos;assertion failed: `(left == right)`&#xA;  left: `4`,&#xA; right: `3`&apos;, src/lib.rs:10:9&#xA;note: Run with `RUST_BACKTRACE=1` for a backtrace.&#xA;" />
     </testcase>
-    <testcase name="tests::success" time="0" />
-    <system-out />
-    <system-err />
+    <testcase name="success" classname="tests" time="0" />
   </testsuite>
 </testsuites>

--- a/src/expected_outputs/multi_suite_success.json.out
+++ b/src/expected_outputs/multi_suite_success.json.out
@@ -1,68 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
   <testsuite id="0" name="cargo test #0" package="testsuite/cargo test #0" tests="5" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:06.568821800+00:00" time="0">
-    <testcase name="sharedkey::create_signature" time="0" />
-    <testcase name="client::list_tables" time="0" />
-    <testcase name="client::delete_tables" time="0" />
-    <testcase name="table::create_and_delete_table" time="0" />
-    <testcase name="blob::create_and_delete_container" time="0" />
-    <system-out />
-    <system-err />
+    <testcase name="create_signature" classname="sharedkey" time="0" />
+    <testcase name="list_tables" classname="client" time="0" />
+    <testcase name="delete_tables" classname="client" time="0" />
+    <testcase name="create_and_delete_table" classname="table" time="0" />
+    <testcase name="create_and_delete_container" classname="blob" time="0" />
   </testsuite>
-  <testsuite id="1" name="cargo test #1" package="testsuite/cargo test #1" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:06.568821800+00:00" time="0">
-    <system-out />
-    <system-err />
-  </testsuite>
-  <testsuite id="2" name="cargo test #2" package="testsuite/cargo test #2" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:06.568821800+00:00" time="0">
-    <system-out />
-    <system-err />
-  </testsuite>
-  <testsuite id="3" name="cargo test #3" package="testsuite/cargo test #3" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:06.568821800+00:00" time="0">
-    <system-out />
-    <system-err />
-  </testsuite>
-  <testsuite id="4" name="cargo test #4" package="testsuite/cargo test #4" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:06.568821800+00:00" time="0">
-    <system-out />
-    <system-err />
-  </testsuite>
-  <testsuite id="5" name="cargo test #5" package="testsuite/cargo test #5" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:06.568821800+00:00" time="0">
-    <system-out />
-    <system-err />
-  </testsuite>
+  <testsuite id="1" name="cargo test #1" package="testsuite/cargo test #1" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:06.568821800+00:00" time="0" />
+  <testsuite id="2" name="cargo test #2" package="testsuite/cargo test #2" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:06.568821800+00:00" time="0" />
+  <testsuite id="3" name="cargo test #3" package="testsuite/cargo test #3" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:06.568821800+00:00" time="0" />
+  <testsuite id="4" name="cargo test #4" package="testsuite/cargo test #4" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:06.568821800+00:00" time="0" />
+  <testsuite id="5" name="cargo test #5" package="testsuite/cargo test #5" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:06.568821800+00:00" time="0" />
   <testsuite id="6" name="cargo test #6" package="testsuite/cargo test #6" tests="3" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:06.568821800+00:00" time="0">
-    <testcase name="types::blob_deserialize" time="0" />
-    <testcase name="types::drop_deserialize" time="0" />
-    <testcase name="types::manifest_deserialize" time="0" />
-    <system-out />
-    <system-err />
+    <testcase name="blob_deserialize" classname="types" time="0" />
+    <testcase name="drop_deserialize" classname="types" time="0" />
+    <testcase name="manifest_deserialize" classname="types" time="0" />
   </testsuite>
   <testsuite id="7" name="cargo test #7" package="testsuite/cargo test #7" tests="5" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:06.568821800+00:00" time="0">
-    <testcase name="chunker::real_rolling_hash" time="0" />
-    <testcase name="chunker::simple_rolling_hash" time="0" />
-    <testcase name="chunker::chunk_bytes" time="0" />
-    <testcase name="blockhash::block_hashes" time="0" />
-    <testcase name="blobhash::blob_hashes" time="0" />
-    <system-out />
-    <system-err />
+    <testcase name="real_rolling_hash" classname="chunker" time="0" />
+    <testcase name="simple_rolling_hash" classname="chunker" time="0" />
+    <testcase name="chunk_bytes" classname="chunker" time="0" />
+    <testcase name="block_hashes" classname="blockhash" time="0" />
+    <testcase name="blob_hashes" classname="blobhash" time="0" />
   </testsuite>
-  <testsuite id="8" name="cargo test #8" package="testsuite/cargo test #8" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:06.568821800+00:00" time="0">
-    <system-out />
-    <system-err />
-  </testsuite>
-  <testsuite id="9" name="cargo test #9" package="testsuite/cargo test #9" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:06.568821800+00:00" time="0">
-    <system-out />
-    <system-err />
-  </testsuite>
-  <testsuite id="10" name="cargo test #10" package="testsuite/cargo test #10" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:06.568821800+00:00" time="0">
-    <system-out />
-    <system-err />
-  </testsuite>
-  <testsuite id="11" name="cargo test #11" package="testsuite/cargo test #11" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:06.568821800+00:00" time="0">
-    <system-out />
-    <system-err />
-  </testsuite>
-  <testsuite id="12" name="cargo test #12" package="testsuite/cargo test #12" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:06.568821800+00:00" time="0">
-    <system-out />
-    <system-err />
-  </testsuite>
+  <testsuite id="8" name="cargo test #8" package="testsuite/cargo test #8" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:06.568821800+00:00" time="0" />
+  <testsuite id="9" name="cargo test #9" package="testsuite/cargo test #9" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:06.568821800+00:00" time="0" />
+  <testsuite id="10" name="cargo test #10" package="testsuite/cargo test #10" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:06.568821800+00:00" time="0" />
+  <testsuite id="11" name="cargo test #11" package="testsuite/cargo test #11" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:06.568821800+00:00" time="0" />
+  <testsuite id="12" name="cargo test #12" package="testsuite/cargo test #12" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:06.568821800+00:00" time="0" />
 </testsuites>

--- a/src/expected_outputs/self.json.out
+++ b/src/expected_outputs/self.json.out
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
   <testsuite id="0" name="cargo test #0" package="testsuite/cargo test #0" tests="5" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:06.724822700+00:00" time="0.081745">
-    <testcase name="tests::error_on_garbage" time="0.0002131" />
-    <testcase name="tests::failded_single_suite" time="0.0005697" />
-    <testcase name="tests::success_single_suite" time="0.0002754" />
-    <testcase name="tests::multi_suite_success" time="0.0021462" />
-    <testcase name="tests::cargo_project_failure" time="0.0785406" />
-    <system-out />
-    <system-err />
+    <testcase name="error_on_garbage" classname="tests" time="0.0002131" />
+    <testcase name="failded_single_suite" classname="tests" time="0.0005697" />
+    <testcase name="success_single_suite" classname="tests" time="0.0002754" />
+    <testcase name="multi_suite_success" classname="tests" time="0.0021462" />
+    <testcase name="cargo_project_failure" classname="tests" time="0.0785406" />
   </testsuite>
 </testsuites>

--- a/src/expected_outputs/self_exec_time.json.out
+++ b/src/expected_outputs/self_exec_time.json.out
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
   <testsuite id="0" name="cargo test #0" package="testsuite/cargo test #0" tests="6" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:06.859908500+00:00" time="0.197">
-    <testcase name="tests::error_on_garbage" time="0" />
-    <testcase name="tests::failded_single_suite" time="0.001" />
-    <testcase name="tests::success_single_suite" time="0.001" />
-    <testcase name="tests::multi_suite_success" time="0.003" />
-    <testcase name="tests::az_func_regression" time="0.072" />
-    <testcase name="tests::cargo_project_failure" time="0.12" />
-    <system-out />
-    <system-err />
+    <testcase name="error_on_garbage" classname="tests" time="0" />
+    <testcase name="failded_single_suite" classname="tests" time="0.001" />
+    <testcase name="success_single_suite" classname="tests" time="0.001" />
+    <testcase name="multi_suite_success" classname="tests" time="0.003" />
+    <testcase name="az_func_regression" classname="tests" time="0.072" />
+    <testcase name="cargo_project_failure" classname="tests" time="0.12" />
   </testsuite>
 </testsuites>

--- a/src/expected_outputs/success.json.out
+++ b/src/expected_outputs/success.json.out
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
   <testsuite id="0" name="cargo test #0" package="testsuite/cargo test #0" tests="1" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:07.005942200+00:00" time="0">
-    <testcase name="tests::success" time="0" />
-    <system-out />
-    <system-err />
+    <testcase name="success" classname="tests" time="0" />
   </testsuite>
-  <testsuite id="1" name="cargo test #1" package="testsuite/cargo test #1" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:07.005942200+00:00" time="0">
-    <system-out />
-    <system-err />
-  </testsuite>
+  <testsuite id="1" name="cargo test #1" package="testsuite/cargo test #1" tests="0" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:07.005942200+00:00" time="0" />
 </testsuites>

--- a/src/expected_outputs/timeout.json.out
+++ b/src/expected_outputs/timeout.json.out
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
   <testsuite id="0" name="cargo test #0" package="testsuite/cargo test #0" tests="1" errors="0" failures="0" hostname="localhost" timestamp="2020-06-15T20:58:07.146949500+00:00" time="0">
-    <testcase name="tests::long_execution_time" time="0" />
-    <system-out />
-    <system-err />
+    <testcase name="long_execution_time" classname="tests" time="0" />
   </testsuite>
 </testsuites>


### PR DESCRIPTION
GitLab apparently needs a `classname`attribute.

I propose that the fully qualified name is split at the last `::` into `{classname}::{name}`

This requires bachp/junit-report-rs#5 to be merged.