### PR TITLE
Handle --enforce-time and --show-output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "derive-getters"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16dc4e2517f08ca167440ccb11023c1308ee19a4022d7b03c0e652f971171869"
+checksum = "0c5905670fd9c320154f3a4a01c9e609733cd7b753f3c58777ab7d5ce26686b3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -57,12 +57,13 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "junit-report"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4e00ad2de771fc4988af88b02cbd618c08c17920208c35c4bbfe67ccfab31eb"
+checksum = "f5723045bee9fb2189ffe40361fb4bf3046bb50486c45fd079fef810af075f2e"
 dependencies = [
  "chrono",
  "derive-getters",
+ "strip-ansi-escapes",
  "thiserror",
  "xml-rs",
 ]
@@ -178,6 +179,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d63676e2abafa709460982ddc02a3bb586b6d15a49b75c212e06edd3933acee"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,6 +243,21 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "utf8parse"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8772a4ccbb4e89959023bc5b7cb8623a795caa7092d99f3aa9501b9484d4557d"
+
+[[package]]
+name = "vte"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f42f536e22f7fcbb407639765c8fd78707a33109301f834a594758bedd6e8cf"
+dependencies = [
+ "utf8parse",
+]
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT"
 maintenance = { status = "experimental" }
 
 [dependencies]
-junit-report = "^0.4.0"
+junit-report = "^0.4.1"
 serde_json = "1.0.38"
 serde = { version = "1.0", features = ["derive"] }
 

--- a/src/expected_outputs/cargo_failure.json.out
+++ b/src/expected_outputs/cargo_failure.json.out
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-  <testsuite id="0" name="cargo test #0" package="testsuite/cargo test #0" tests="25" errors="0" failures="0" hostname="localhost" timestamp="2020-06-16T06:16:58.513211709+00:00" time="0">
+  <testsuite id="0" name="cargo test #0" package="testsuite/cargo test #0" tests="25" errors="0" failures="0" hostname="localhost" timestamp="2021-03-07T00:01:54.212806+00:00" time="0">
     <testcase name="bad_parsing" classname="core::package_id_spec::tests" time="0" />
     <testcase name="good_parsing" classname="core::package_id_spec::tests" time="0" />
     <testcase name="invalid_version_handled_nicely" classname="core::package_id::tests" time="0" />
@@ -27,10 +27,20 @@
     <testcase name="with_retry_finds_nested_spurious_errors" classname="util::network" time="0" />
     <testcase name="test_lev_distance" classname="util::lev_distance" time="0" />
   </testsuite>
-  <testsuite id="1" name="cargo test #1" package="testsuite/cargo test #1" tests="1503" errors="0" failures="2" hostname="localhost" timestamp="2020-06-16T06:16:58.513211709+00:00" time="0">
+  <testsuite id="1" name="cargo test #1" package="testsuite/cargo test #1" tests="1503" errors="0" failures="2" hostname="localhost" timestamp="2021-03-07T00:01:54.212806+00:00" time="0">
     <testcase name="bad_registry_name" classname="alt_registry" time="0" />
     <testcase name="aaa_trigger_cross_compile_disabled_check" classname="" time="0">
-      <failure type="cargo test" message="thread &apos;aaa_trigger_cross_compile_disabled_check&apos; panicked at &apos;Cannot cross compile to i686-pc-windows-msvc.&#xA;&#xA;This failure can be safely ignored. If you would prefer to not see this&#xA;failure, you can set the environment variable CFG_DISABLE_CROSS_TESTS to &quot;1&quot;.&#xA;&#xA;Alternatively, you can install the necessary libraries for cross-compilation with&#xA;&#xA;    rustup target add i686-pc-windows-msvc&#xA;&apos;, tests\testsuite\support\cross_compile.rs:92:5&#xA;note: Run with `RUST_BACKTRACE=1` for a backtrace.&#xA;" />
+      <failure type="cargo test" message="failed"><![CDATA[thread 'aaa_trigger_cross_compile_disabled_check' panicked at 'Cannot cross compile to i686-pc-windows-msvc.
+
+This failure can be safely ignored. If you would prefer to not see this
+failure, you can set the environment variable CFG_DISABLE_CROSS_TESTS to "1".
+
+Alternatively, you can install the necessary libraries for cross-compilation with
+
+    rustup target add i686-pc-windows-msvc
+', tests\testsuite\support\cross_compile.rs:92:5
+note: Run with `RUST_BACKTRACE=1` for a backtrace.
+]]></failure>
     </testcase>
     <testcase name="alt_reg_metadata" classname="alt_registry" time="0" />
     <testcase name="cannot_publish_to_crates_io_with_registry_dependency" classname="alt_registry" time="0" />
@@ -332,7 +342,45 @@
     <testcase name="ssh_something_happens" classname="build_auth" time="0" />
     <testcase name="build_with_no_lib" classname="build_lib" time="0" />
     <testcase name="http_auth_offered" classname="build_auth" time="0">
-      <failure type="cargo test" message="running `C:\src\rust-lang\cargo\target\debug\cargo.exe build -v`&#xA;running `C:\src\rust-lang\cargo\target\debug\cargo.exe build`&#xA;thread &apos;build_auth::http_auth_offered&apos; panicked at &apos;&#xA;Expected: execs&#xA;    but: expected to find:&#xA;[UPDATING] git repository `http://127.0.0.1:33960/foo/bar`&#xA;[ERROR] failed to load source for a dependency on `bar`&#xA;&#xA;Caused by:&#xA;  Unable to update http://127.0.0.1:33960/foo/bar&#xA;&#xA;Caused by:&#xA;  failed to clone into: [..]&#xA;&#xA;Caused by:&#xA;  failed to authenticate when downloading repository&#xA;attempted to find username/password via `credential.helper`, but [..]&#xA;&#xA;Caused by:&#xA;&#xA;&#xA;did not find in output:&#xA;    Updating git repository `http://127.0.0.1:33960/foo/bar`&#xA;error: failed to load source for a dependency on `bar`&#xA;&#xA;Caused by:&#xA;  Unable to update http://127.0.0.1:33960/foo/bar&#xA;&#xA;Caused by:&#xA;  failed to clone into: C:\src\rust-lang\cargo\target\cit\t263\home\.cargo\git\db\bar-8cbd35f4772f62e3&#xA;&#xA;Caused by:&#xA;  failed to authenticate when downloading repository&#xA;attempted to find username/password via git&apos;s `credential.helper` support, but failed&#xA;&#xA;Caused by:&#xA;  failed to acquire username/password from local configuration&#xA;&apos;, tests\testsuite\support\mod.rs:794:13&#xA;" />
+      <failure type="cargo test" message="failed"><![CDATA[running `C:\src\rust-lang\cargo\target\debug\cargo.exe build -v`
+running `C:\src\rust-lang\cargo\target\debug\cargo.exe build`
+thread 'build_auth::http_auth_offered' panicked at '
+Expected: execs
+    but: expected to find:
+[UPDATING] git repository `http://127.0.0.1:33960/foo/bar`
+[ERROR] failed to load source for a dependency on `bar`
+
+Caused by:
+  Unable to update http://127.0.0.1:33960/foo/bar
+
+Caused by:
+  failed to clone into: [..]
+
+Caused by:
+  failed to authenticate when downloading repository
+attempted to find username/password via `credential.helper`, but [..]
+
+Caused by:
+
+
+did not find in output:
+    Updating git repository `http://127.0.0.1:33960/foo/bar`
+error: failed to load source for a dependency on `bar`
+
+Caused by:
+  Unable to update http://127.0.0.1:33960/foo/bar
+
+Caused by:
+  failed to clone into: C:\src\rust-lang\cargo\target\cit\t263\home\.cargo\git\db\bar-8cbd35f4772f62e3
+
+Caused by:
+  failed to authenticate when downloading repository
+attempted to find username/password via git's `credential.helper` support, but failed
+
+Caused by:
+  failed to acquire username/password from local configuration
+', tests\testsuite\support\mod.rs:794:13
+]]></failure>
     </testcase>
     <testcase name="build_lib_only" classname="build_lib" time="0" />
     <testcase name="https_something_happens" classname="build_auth" time="0" />

--- a/src/expected_outputs/failed.json.out
+++ b/src/expected_outputs/failed.json.out
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites>
-  <testsuite id="0" name="cargo test #0" package="testsuite/cargo test #0" tests="2" errors="0" failures="1" hostname="localhost" timestamp="2020-06-15T20:58:06.406283700+00:00" time="0">
+  <testsuite id="0" name="cargo test #0" package="testsuite/cargo test #0" tests="2" errors="0" failures="1" hostname="localhost" timestamp="2021-03-07T00:01:47.350619400+00:00" time="0">
     <testcase name="fails" classname="tests" time="0">
-      <failure type="cargo test" message="thread &apos;tests::fails&apos; panicked at &apos;assertion failed: `(left == right)`&#xA;  left: `4`,&#xA; right: `3`&apos;, src/lib.rs:10:9&#xA;note: Run with `RUST_BACKTRACE=1` for a backtrace.&#xA;" />
+      <failure type="cargo test" message="failed"><![CDATA[thread 'tests::fails' panicked at 'assertion failed: `(left == right)`
+  left: `4`,
+ right: `3`', src/lib.rs:10:9
+note: Run with `RUST_BACKTRACE=1` for a backtrace.
+]]></failure>
     </testcase>
     <testcase name="success" classname="tests" time="0" />
   </testsuite>

--- a/src/expected_outputs/timed_out.json.out
+++ b/src/expected_outputs/timed_out.json.out
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite id="0" name="cargo test #0" package="testsuite/cargo test #0" tests="1" errors="0" failures="1" hostname="localhost" timestamp="2021-03-06T23:56:08.701117400+00:00" time="1.0120183">
+    <testcase name="long_execution_time" classname="tests" time="1.0120183">
+      <failure type="cargo test" message="time limit exceeded" />
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/src/test_inputs/timed_out.json
+++ b/src/test_inputs/timed_out.json
@@ -1,0 +1,4 @@
+{ "type": "suite", "event": "started", "test_count": 1 }
+{ "type": "test", "event": "started", "name": "tests::long_execution_time" }
+{ "type": "test", "name": "tests::long_execution_time", "event": "failed", "exec_time": 1.0120183, "reason": "time limit exceeded" }
+{ "type": "suite", "event": "failed", "passed": 0, "failed": 1, "allowed_fail": 0, "ignored": 0, "measured": 0, "filtered_out": 10, "exec_time": 1.0151028 }


### PR DESCRIPTION
This change adds support for tests that fail due to timeout (via
Rust's --enforce-time flag). This is achieved by treating a test
event's `stdout` as optional and passing through the contents of
`reason`. Previously such a test event led to a parsing error.

The change also adds support for passing through stdout for passing
tests (generated via Rust's --show-output). Previously this data
was silently dropped.

This raises the question of where to include this new information in
the output XML. For passing tests, the contents of stdout is included
in the `<system-out>` node, via `TestCase::system_out`.

For failing tests, the contents of stdout was previously included
in the `message` XML attribute, via `TestResult::Failed::message`. It
seems more correct to include this as the inner text of the
`<failure>` node and to put `reason` (if it exists) into `message`.
Doing this requires upgrading to junit-result 0.4.1, which (for better
or for worse) changes the target of `TestCase::system_out` for failed
tests from the `<system-out>` node to the `<failure>` node.