### PR TITLE
cargo2junit should indicate test failure via exit code for easy CI integration

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -285,6 +285,19 @@ fn main() -> Result<()> {
         .write_xml(&mut stdout)
         .map_err(|e| Error::new(ErrorKind::Other, format!("{}", e)))?;
     writeln!(stdout)?;
+
+    if report
+        .testsuites()
+        .iter()
+        .map(|suite| suite.testcases().iter())
+        .flatten()
+        .any(|testcase| testcase.is_error() || testcase.is_failure())
+    {
+        // Return non-zero exit code as cargo-test would do
+        eprintln!("Some tests failed");
+        std::process::exit(1);
+    }
+
     Ok(())
 }
 

--- a/src/test_inputs/one_suite_no_tests.json
+++ b/src/test_inputs/one_suite_no_tests.json
@@ -1,0 +1,2 @@
+{ "type": "suite", "event": "started", "test_count": 0 }
+{ "type": "suite", "event": "ok", "passed": 0, "failed": 0, "allowed_fail": 0, "ignored": 0, "measured": 0, "filtered_out": 0, "exec_time": 0.0000924 }


### PR DESCRIPTION
Thank you for offering `cargo2junit`! We recently added it to our GitLab CI environment and have much nicer reporting now!

Unfortunately, we noticed that it broke the result propagation. We pipe the `cargo test` results into `cargo2junit` as suggested by the README: `cargo test -- -Z unstable-options --format json --report-time | cargo2junit > results.xml`. This approach masks the exit code of `cargo test` which we depend on to report failure. GitLab does not care about failures in the junit report to fail CI jobs.

This PR adds code that analyses the test results and makes `cargo2junit` exit with 1 on failure, which fixes the reporting for us.

Note that it sits on top of #56, as we need an interface to inspect the test report.