### PR TITLE
Handle test logs starting with {

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -344,8 +344,8 @@ mod tests {
     }
 
     #[test]
-    fn error_on_garbage() {
-        assert!(parse_string("{garbage}", SYSTEM_OUT_MAX_LEN).is_err());
+    fn no_error_on_garbage() {
+        assert!(parse_string("{garbage}", SYSTEM_OUT_MAX_LEN).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Don't error out when parsing a line starting with '{' but can't be parsed as JSON test output. Just ignore it the same way we do all lines not starting with '{'. It could instead be the code under test writing logs starting '{' (which is what we're hitting 🙂).

This is normally avoided by splitting cargo test output and test logs, but isn't possible under cargo-llvm-cov which redirects it all to stderr.

Signed-off-by: Nigel Thorpe <nigel.thorpe@metaswitch.com>