### PR TITLE
Make it possible to set suite name prefix.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -332,7 +332,11 @@ fn main() -> Result<()> {
             .expect("Failed to parse TEST_STDOUT_STDERR_MAX_LEN as a natural number"),
         Err(_) => SYSTEM_OUT_MAX_LEN,
     };
-    let report = parse(stdin, "cargo test", timestamp, max_out_len)?;
+
+    // Lets someone running many tests specify a custom suite name prefix
+    let suite_name_prefix = env::var("TEST_SUITE_NAME_PREFIX").unwrap_or_else(|_| "cargo test".to_owned());
+
+    let report = parse(stdin, &suite_name_prefix, timestamp, max_out_len)?;
 
     let stdout = std::io::stdout();
     let mut stdout = stdout.lock();


### PR DESCRIPTION
In a CI environment where tests for many different packages are executed and reports are gathered, it becomes difficult to separate them from each other. For example Jenkins will get confused and try to merge all reports together.

By allowing the system running the tests to override the prefix it can use e.g. the package name as a prefix to work around this issue.